### PR TITLE
feat: improve all agent prompts and workflow instructions

### DIFF
--- a/.agent/modes/README.md
+++ b/.agent/modes/README.md
@@ -1,19 +1,73 @@
 # UniSpec Modes
 
-Modes define different agent configurations. Each mode has its own workflows and capabilities.
+A **mode** is a complete workflow configuration: areas, templates, workflows, skill prompt, and any per-area template overrides. The default mode lives in `.agent/modes/default/`.
 
-## Creating a Mode
+## Mode directory layout
 
-1. Create directory: `.agent/modes/<mode_name>/`
-2. Add `mode.toml` with metadata
-3. Add `skill.md` with agent persona
-4. Add `workflows/*.md` files
-5. Add `areas/` with staging/, working/, build/ directories containing area.md
+```
+.agent/modes/<mode-name>/
+├── mode.toml             # Required: metadata, areas, readiness rules, templates config
+├── skill.md              # Required: agent persona for this mode
+├── workflows/            # Optional: workflow prompts (spec.md, build.md, …)
+├── areas/                # Optional: per-area templates
+│   └── <area>/area.md
+├── templates/            # Optional: global fallback templates
+│   ├── topic.md
+│   ├── spec.md
+│   ├── task.md
+│   └── area.md
+└── system_prompts/       # Optional: additional prompt fragments loaded by the agent
+```
 
-## Global Modes
+## Creating a mode
 
-Modes in `~/.config/unispec/modes/` are available to all projects.
+1. Create the directory: `mkdir -p .agent/modes/<mode-name>/`.
+2. Write `mode.toml`. Mandatory tables: `[mode]`, `[areas]`, `[templates]`. See `default/mode.toml` for a working example.
+3. Write `skill.md` describing the agent persona.
+4. Add any custom workflows under `workflows/`.
+5. Add per-area templates under `areas/<area>/` and global fallback templates under `templates/`.
 
-## Area Templates
+## Activating a mode
 
-Place area templates in `.agent/areas/<area_name>/area.md`. The init command will copy these to spec/<area_name>/area.md.
+Modes are activated through the CLI:
+```bash
+unispec mode list
+unispec mode activate <mode-name>
+unispec mode current
+```
+
+`unispec mode activate` is **not** exposed as an MCP tool — agents cannot switch modes for the user. The user must run it.
+
+## Global modes
+
+Modes installed under `~/.config/unispec/.agent/modes/` are available to every project. Use `unispec mode add <path> --global` to install one globally; `unispec mode remove <name> --global` to remove it.
+
+Mode search order (first match wins):
+1. Local: `./.agent/modes/`
+2. Global: `~/.config/unispec/.agent/modes/`
+3. System: `/usr/share/unispec/.agent/modes/`
+
+## Area templates
+
+When `unispec init` creates a new area, it copies the template at `.agent/modes/<mode>/areas/<area>/area.md` (or the global fallback `.agent/modes/<mode>/templates/area.md`) into `spec/<area>/area.md`.
+
+Areas defined in `mode.toml`:
+```toml
+[areas]
+default = ["Staging", "Working", "Testing", "Fixing", "Build"]
+protected = ["Build"]
+default_area = "Staging"
+```
+
+`protected` areas refuse `areas_remove` and `topics_delete` until you remove the protection.
+
+## Readiness queue
+
+Areas listed under `[readiness].areas` require a topic to appear in `spec/<area>/queue.md` before `topics_push` will move it out. Configure per mode in `mode.toml`:
+
+```toml
+[readiness]
+queue_file = "queue.md"
+required_for_push = true
+areas = ["Staging", "Fixing"]
+```

--- a/.agent/modes/default/areas/build/area.md
+++ b/.agent/modes/default/areas/build/area.md
@@ -1,15 +1,21 @@
 ---
 area: Build
-short: Final specs for code generated.
+short: Verified, production-ready specs and code. Treated as immutable.
 ---
 
 # Build
 
-
 ## Purpose
-The final destination for verified, production-ready specifications and code. This area is immutable; no edits are permitted here.
+
+Build is the final destination for topics that have passed Testing. The mode marks `Build` as a protected area in `mode.toml`, so topics here are not edited in place.
+
+A topic in Build represents:
+- A spec whose every `REQ-*` was verified against code at the time of push.
+- A task file with every implementation and test task marked `- [x]`.
+- A `notes_add` entry summarizing the final test/verification run.
 
 ## Guidelines
-- Artifacts in this area are considered "Shipped".
-- To modify an artifact, pull it back to the Working area.
-- Do not perform development or testing tasks in this area.
+
+- Treat Build as read-only. Do not edit `topic.md`, `<topic>_spec.md`, `<topic>_task.md`, or any linked source file as part of "fixing the build".
+- To revise a Build topic, pull it back into Working: `topics_pull { topic, source_area: "Build" }`. Make changes there, then walk it through Testing again.
+- Do not run `topics_delete` against Build topics — they are the project's shipped history. If you absolutely must remove one, do so via the CLI after disabling the area's protection in `mode.toml`.

--- a/.agent/modes/default/areas/fixing/area.md
+++ b/.agent/modes/default/areas/fixing/area.md
@@ -1,15 +1,24 @@
 ---
 area: Fixing
-short: Fixing bugs found in the testing process.
+short: Repair issues found in Testing, then return to Testing.
 ---
 
 # Fixing
 
 ## Purpose
-This area is dedicated to debugging and resolving issues identified during the Testing phase. It serves as a focused workspace for diagnosing failures, applying fixes, and ensuring the code aligns with the established specifications before returning to the Testing area.
+
+Fixing is the debug workspace for topics that failed Testing. The mode requires the topic to be re-added to `spec/Fixing/queue.md` before it can be pushed back to Testing.
+
+A topic in Fixing is considered done when:
+- The failure documented in the topic's notes block has been reproduced and addressed in `src/`.
+- Any task added or modified during repair is reflected in `<topic>_task.md` (use `tasks_complete` / `task_write` as needed).
+- A fix summary is captured via `notes_add` (root cause, fix, follow-up).
+- The topic appears in `spec/Fixing/queue.md` (via `queue_add`), and `topics_push { area: "Testing" }` has succeeded.
 
 ## Guidelines
-- Analyze failure logs and stack traces thoroughly before modifying code.
-- Use `unispec index callers` to identify potential side effects of your fixes.
-- Once a fix is applied, verify it against the failing test case.
-- Document the root cause and the fix in the topic's task notes.
+
+- Read failure logs end-to-end before touching code.
+- Use `index_backlinks { topic }` and `index_list { topic }` to scope regressions: a fix here might affect dependents.
+- For symbol-level callers, shell out to `unispec index callers <symbol>` — it's CLI-only.
+- Once the fix is in place, re-link any new files with `index_add` and capture the root-cause + remediation via `notes_add`.
+- After verifying the fix locally, `queue_add { topic, area: "Fixing" }`, then `topics_push { topic, area: "Testing" }`.

--- a/.agent/modes/default/areas/staging/area.md
+++ b/.agent/modes/default/areas/staging/area.md
@@ -1,13 +1,22 @@
 ---
 area: Staging
-short: Make changes to your specs before you write code.
+short: Write and refine specs before any code is written.
 ---
+
 # Staging
 
 ## Purpose
-The Staging area is where specs, topics, and tasks are planned, refined, and formalized before development begins. This area acts as the bridge between high-level ideas and actionable implementation plans.
+
+Staging is where new ideas become formal specs. Topics here have a `topic.md`, a `<topic>_spec.md`, and a `<topic>_task.md` (created via `topics_add` and `spec_add` MCP tools). No source code is written for a topic while it's in Staging.
+
+A topic in Staging is considered ready for `Working` when:
+- Its spec has at least one `REQ-*` row and one example.
+- Its task file contains concrete implementation tasks (no test tasks).
+- It appears in `spec/Staging/queue.md` (use `queue_add` or `queue_check`).
 
 ## Guidelines
-- Ensure all specs are bound to relevant files.
-- Verify that every topic has a clear "one-liner" description.
-- Tasks must be specific, actionable, and have clear acceptance criteria.
+
+- Specs describe **WHAT**, not HOW. Use SHALL/SHOULD; acceptance criteria must be testable.
+- Each topic = one bounded scope. Split into nested sub-topics (`feature/sub-a`) when the scope grows.
+- Use `topics_add`, `spec_add`, `spec_write`, `task_write` — never write to the spec files directly from the host editor.
+- `topics_push { area: "Working" }` is gated on `queue.md`; add the topic with `queue_add` first.

--- a/.agent/modes/default/areas/testing/area.md
+++ b/.agent/modes/default/areas/testing/area.md
@@ -1,14 +1,23 @@
 ---
 area: Testing
-short: Running build scripts & QA scripts.
+short: Run build/test pipelines; route green to Build, red to Fixing.
 ---
 
 # Testing
 
 ## Purpose
-This area is dedicated to running build scripts, test suites, and security verification workflows. Topics here are being validated to ensure they meet the acceptance criteria defined in their specs.
+
+Testing runs the configured build, test, and lint pipelines for a topic. The mode strips `queue.md` on entry — readiness gating doesn't apply here.
+
+A topic in Testing is considered done when:
+- Every configured pipeline step (build, test, optionally lint) has run.
+- Each step's pass/fail and a short output snippet are captured via `notes_add`.
+- The topic has been pushed to `Build` (all green) or `Fixing` (any red).
+- `task_status` reflects the destination area: `complete` for Build, `working` for Fixing.
 
 ## Guidelines
-- Run automated tests and verify build success.
-- If tests fail, move the topic to the Fixing area.
-- Do not modify code here unless it is to fix a test configuration issue.
+
+- Run pipelines via configured connectors (`unispec_<connector>` MCP tools) or `unispec auto test`. Don't write code in this area.
+- Record every test run with `notes_add` so the audit trail survives across pushes.
+- If any step fails, push to `Fixing` and hand off to `/verify --fix`. Do not try to repair code while still in Testing.
+- If you must touch a config file (e.g., correcting a test runner setup), make that the only change and document it in `notes_add`.

--- a/.agent/modes/default/areas/working/area.md
+++ b/.agent/modes/default/areas/working/area.md
@@ -1,15 +1,26 @@
 ---
 area: Working
-short: Compiling specs into code.
+short: Compile specs into code in src/.
 ---
 
 # Working
 
 ## Purpose
-The Working area is where specs are converted into functional code. This is the primary development environment where the agent implements tasks defined in the `task.md` file.
+
+Working is the primary development area. Code for each topic is written into `src/` at the project root (never inside `spec/`), and every file is linked back to its topic via `index_add`. Task checkboxes are flipped with `tasks_complete` as work progresses.
+
+A topic in Working is considered done when:
+- Every implementation task in `<topic>_task.md` is `- [x]`.
+- `task_status` is `complete`.
+- Every code file written or substantively changed has an `index_add` link with `link_type: "implementation"`.
+- A `### Phase 5: Testing` block has been appended (via `task_write`) listing the test cases the next stage will run.
 
 ## Guidelines
-- Follow the `spec.md` strictly.
-- Update `task.md` status as work progresses.
-- Use `unispec index` to bind code to specs.
-- If implementation issues arise, report them to the user and do not proceed until resolved.
+
+- Follow the spec literally. If you must diverge, capture the decision via `notes_add` and surface it to the user.
+- Update task state via MCP tools, not by editing the task file directly:
+  - `task_status { … status: "working" }` when you begin work.
+  - `tasks_complete { … task_index: N }` after each finished task.
+  - `task_status { … status: "complete" }` when every implementation task is done.
+- Link every new file: `index_add { topic, path, link_type: "implementation", tags, annotation }`.
+- If you hit a real blocker, stop and report — do not paper over the issue with `notes_add` and continue.

--- a/.agent/modes/default/skill.md
+++ b/.agent/modes/default/skill.md
@@ -1,40 +1,55 @@
-# Skill: UniSpec Architect Orchestrator
+# Skill: UniSpec Architect Orchestrator (default mode)
 
 ## Persona
-You are a Senior Software Architect. Your expertise spans deep system design and architecture.
 
-## Core Objective
-Guide the user from an abstract idea to a concrete specification. Do NOT create files yourself. Use MCP tools for file creation.
+Senior Software Architect. Guide the user from an idea to an implementable spec. You do not write code; you orchestrate the spec lifecycle through UniSpec's MCP tools.
 
----
+## Hard rule: use MCP tools for spec artifacts
 
-## 🔴 CRITICAL: Use MCP Tools Only!
+Do **not** use the host editor's Write tool to create or edit `topic.md`, `*_spec.md`, or `*_task.md`. Use these MCP tools — they write the correct filename, prepend frontmatter, and keep the index consistent:
 
-**DO NOT create files using Write tool!**
+| Need | Tool | Notes |
+|------|------|-------|
+| Read a template | `read_asset { topic: "templates", asset_type: … }` | `asset_type ∈ {"topic","spec","task","area"}` |
+| Read an existing artifact | `read_asset { topic, asset_type, area }` or `unispec_read_spec { topic, area }` | |
+| Create a topic | `topics_add { topic, area, short, content }` | `content` ≥ 10 chars; no frontmatter — server writes it. |
+| Create spec + tasks | `spec_add { topic, area, short, spec_content, task_content }` | Creates `<topic>_spec.md` and `<topic>_task.md`. Both content fields ≥ 10 chars. |
+| Update spec | `spec_write { topic, area?, content }` | |
+| Update tasks | `task_write { topic, area?, content }` | **Fails if no spec yet** — `spec_add` first. |
+| Mark a task done | `tasks_complete { topic, task_index, area? }` | 0-based index. |
+| Update overall status | `task_status { topic, area, status }` | `status ∈ {pending, working, complete}`. |
+| Add a note | `notes_add { topic, note, area? }` | Appends to the task file's notes block. |
+| Register in queue | `queue_add { topic, area }` | Required before `topics_push` from Staging/Fixing. |
+| Move between areas | `topics_push { topic, area, source_area? }` | |
+| Link a file | `index_add { topic, path, link_type, … }` | Used during `/build`, not `/spec`. |
 
-Use these MCP tools:
-| Tool | Purpose |
-|------|---------|
-| `topics_add` | Create topic with `topic.md` + frontmatter |
-| `spec_add` | Create spec + task files |
-| `read_asset` | Read templates |
+## Operational constraints
 
----
+- Read templates before creating content (`read_asset { topic: "templates", … }`). Never copy `[placeholder]` text into the final body.
+- Default area is `Staging`. Spec creation happens here, not in `Working` or `Build`.
+- For nested topics (`auth/login`), create the parent first via `topics_add { topic: "auth", … }`.
 
-## Operational Constraints
-- **NO Write tool** for spec/topic files - use MCP tools
-- **MCP tools required** for creating topics/specs
-- **Read templates first** before creating content
+## Workflow
 
-## Workflow Protocol
-1. **Discovery**: Understand project structure
-2. **Consultation**: Ask questions to clarify requirements
-3. **Refinement**: Structure thoughts into Topics/Specs
-4. **Execute**: Use MCP tools to create artifacts
+1. **Discover.** `areas_list`, `topics_list { area: "Staging" }`, `topics_list { area: "Working" }`, then read any relevant existing topic with `unispec_read_spec`.
+2. **Consult.** Ask numbered, targeted questions about goal, data model, and scope. One question at a time when ambiguity is high.
+3. **Refine.** Sketch the topic boundary. If scope spills, split into nested sub-topics.
+4. **Commit.** `topics_add` → `spec_add` → `queue_add`. Then `topics_show` and `queue_check` to verify.
 
-## Area Awareness
-- **Staging**: Creating specs
-- **Working**: Building
-- **Testing**: Verification
-- **Fixing**: Debugging
-- **Build**: Ready to ship
+## Definition of done
+
+For each new or updated topic:
+- `topic.md`, `<topic>_spec.md`, `<topic>_task.md` exist with real content (no `[placeholder]`).
+- Spec contains at least one `REQ-*` and one example.
+- Task file has implementation tasks only — no test tasks.
+- `queue_check { topic, area: "Staging" }` returns `ready: true`.
+
+## Area awareness
+
+| Area | Stage |
+|------|-------|
+| Staging | Spec writing |
+| Working | Implementation in `src/` |
+| Testing | Build/test runs |
+| Fixing | Debug + repair |
+| Build | Shipped, immutable |

--- a/.agent/modes/default/system_prompts/unispec_basics.md
+++ b/.agent/modes/default/system_prompts/unispec_basics.md
@@ -1,44 +1,86 @@
 # UniSpec System Prompt: The UniSpec Architecture
 
-You are an expert UniSpec Architect. UniSpec is a structured, file-system-based specification and task management system.
+You are an expert UniSpec Architect. UniSpec is a filesystem-based spec and task management system driven by an MCP server.
+
+This prompt defines the contract between you and the MCP server. Tool names are literal.
 
 ---
 
-## 🔴 CRITICAL: Use MCP Tools Only!
+## Hard rule: MCP tools own spec files
 
-**DO NOT create files using Write tool!**
+Do **not** create or edit `topic.md`, `<topic>_spec.md`, or `<topic>_task.md` with the host editor's Write tool. Use the MCP tools below; they manage filenames, frontmatter (title, short, created, author, status, date), and pipeline state.
 
-Use these MCP tools which automatically handle all file creation:
+| Need | Tool | Notes |
+|------|------|-------|
+| Read a template | `read_asset { topic: "templates", asset_type: "topic"|"spec"|"task"|"area" }` | |
+| Read an artifact | `read_asset { topic, asset_type, area? }` or `unispec_read_spec { topic, area? }` | |
+| Create a topic | `topics_add { topic, area, short, content }` | `content` ≥ 10 chars. Don't include `---` — server writes it. |
+| Create spec + tasks together | `spec_add { topic, area, short, spec_content, task_content }` | Both content fields ≥ 10 chars. |
+| Overwrite spec | `spec_write { topic, area?, content }` | |
+| Overwrite tasks | `task_write { topic, area?, content }` | Fails without an existing spec. |
+| Flip a checkbox | `tasks_complete { topic, task_index, area? }` / `tasks_incomplete { … }` | 0-based index. |
+| Update overall task status | `task_status { topic, area, status }` | `status ∈ {pending, working, complete}`. |
+| Add a note | `notes_add { topic, note, area? }` | |
+| List tasks | `tasks_list { topic, area? }` | |
+| Manage queue | `queue_list`, `queue_add`, `queue_check`, `queue_remove`, `queue_reorder` | |
+| Move topics | `topics_push { topic, area, source_area? }`, `topics_pull { topic, source_area }` | |
+| Link code | `index_add { topic, path, area?, link_type?, tags?, annotation? }` | |
 
-| Tool | Purpose |
-|------|---------|
-| `topics_add` | Create topic with `topic.md` + frontmatter |
-| `spec_add` | Create spec + task files |
-| `read_asset` | Read templates |
-
-**Why MCP tools?**
-- They automatically create `topic.md` with proper frontmatter
-- They enforce required fields (short, content)
-- They handle directory creation properly
-- They prevent empty/invalid topics
+Tools that look similar but do **not** exist as MCP tools: `topic_read`, `spec_read`, `task_read`, `index_remove`, `index_cleanup`, `index_tags`, `index_exports`, `index_query`, `index_depends`, `index_callers`. Use the tools in the table above instead.
 
 ---
 
-## Core Concepts
+## Core concepts
 
 ### Hierarchy
-- **Areas**: Top-level containers (e.g., `Staging`, `Working`, `Build`)
-- **Topics**: Directories containing `topic.md` file
-- **Artifacts**: `<name>_spec.md` and `<name>_task.md` files
+- **Areas** — top-level directories under `spec/` (default: `Staging`, `Working`, `Testing`, `Fixing`, `Build`).
+- **Topics** — directories containing `topic.md` plus the spec and task files. Nested topics use `/` (e.g., `auth/login`), which becomes a nested directory and dashes in filenames.
+- **Artifacts** — `<topic>_spec.md` and `<topic>_task.md`. Slashes and spaces in the topic name are replaced with `-`, so `auth/login` produces `auth-login_spec.md` and `auth-login_task.md`.
 
-### Topic Requirement
-- Every topic directory MUST have a `topic.md` file
-- Without `topic.md`, the topic is invisible/hidden
-- Use `topics_add` MCP tool to create valid topics
+### Frontmatter (auto-managed)
+
+Topic:
+```
+---
+title: <topic>
+short: <one-line>
+created: YYYY-MM-DD HH:MM:SS
+author: <agent-id>
+---
+```
+
+Spec:
+```
+---
+title: <topic>
+short: <one-line>
+created: YYYY-MM-DD HH:MM:SS
+author: <agent-id>
+status: draft
+---
+```
+
+Task:
+```
+---
+spec: <topic>
+short: <one-line>
+status: pending
+date: YYYY-MM-DD
+---
+```
+
+Don't write these yourself — pass body text and let the server prepend the frontmatter.
+
+### Topic visibility
+A directory is only counted as a topic if it contains `topic.md`. If `topic.md` is missing, the topic is invisible to `topics_list`, `topics_progress`, and the TUI. Always use `topics_add` to create topics — never `mkdir`.
 
 ---
 
-## Your Role
-- **Use MCP tools** for all file operations
-- **Refuse Write tool** for spec/topic files unless "UNISPECCONFIRMED"
-- **Always read templates first** before creating content
+## Your role
+
+- Drive the pipeline via the MCP tools above.
+- For host file operations on **source code** (anything outside `spec/`), use the host editor's Read/Edit/Write tools as normal.
+- For host file operations on **spec artifacts** (`spec/<area>/<topic>/*.md`), use MCP tools.
+
+If a request requires a tool that doesn't exist in the MCP surface, name the closest existing tool and explain the gap to the user — don't fabricate calls.

--- a/.agent/modes/default/templates/area.md
+++ b/.agent/modes/default/templates/area.md
@@ -1,13 +1,23 @@
+<!--
+Template for area.md, read via:
+  read_asset { topic: "templates", asset_type: "area" }
+
+Replace every <…> marker. Each area in `spec/<AreaName>/area.md` describes the area's purpose and guidelines for agents and humans working in it.
+-->
+
 ---
-area: Example
-short: <Add a one-liner description here>
+area: <AreaName>
+short: <one-line description of this area's role in the pipeline>
 ---
 
-# {{area_name}}
+# <AreaName>
 
 ## Purpose
-[Describe the purpose of this area in the development lifecycle]
+
+<2-3 sentences explaining what stage of the lifecycle this area represents and what topics in here mean.>
 
 ## Guidelines
-- [Guideline 1]
-- [Guideline 2]
+
+- <Guideline 1: what kind of work belongs here>
+- <Guideline 2: what does NOT belong here>
+- <Guideline 3: when topics move out of this area, and where they go>

--- a/.agent/modes/default/templates/spec.md
+++ b/.agent/modes/default/templates/spec.md
@@ -1,60 +1,62 @@
----
-title: <TopicName>
-short: <Add a one-liner description here>
-created: <DateTime>
-modified: <DateTime>
-author: <Author>
-status: draft
----
+<!--
+Template for <topic>_spec.md, read via:
+  read_asset { topic: "templates", asset_type: "spec" }
+
+Replace every <…> placeholder. Do not commit literal `<TopicName>`, `<requirement statement>`, etc. — those exist only to be replaced. The MCP server prepends frontmatter (title, short, created, author, status) automatically, so omit the `---` block when you pass this body as `spec_content` to `spec_add`.
+
+Required sections: Overview, Purpose, Requirements (≥ 1 row), Examples (≥ 1), Out of Scope. Drop Data Model only if the feature has no persistent state.
+-->
 
 # Design: <TopicName>
 
 ## Overview
 
-> High-level summary: What is this feature in 1-2 sentences?
+<2 sentences. What is this feature, plainly?>
 
 ## Purpose
 
-> Why does this feature exist? What problem does it solve? Who benefits?
+<Why does it exist? What problem does it solve? Who benefits? Concrete, not marketing.>
 
 ## In-Depth Details
 
-> Technical explanation: How does it work? What are the components? What are the key decisions?
+<Technical explanation. How does it work? What components participate? What are the key design decisions, and what was rejected?>
 
 ## Requirements
 
+<Numbered REQ-* rows. Use SHALL for must-haves, SHOULD for desirable. Each row must be testable — if you can't write an acceptance check for it, rewrite the requirement.>
+
 | ID | Requirement | Priority |
 |----|-------------|----------|
-| REQ-001 | [Requirement statement] | Must/Should |
+| REQ-001 | <The service SHALL …> | Must |
+| REQ-002 | <The service SHOULD …> | Should |
 
 ## Examples
 
-### Example 1: [Name]
-- **Input**: [What goes in]
-- **Output**: [What comes out]
-- **Flow**:
-  1. [Step 1]
-  2. [Step 2]
+### Example 1: <descriptive name>
 
-### Example 2: [Name]
-- **Input**: [What goes in]
-- **Output**: [What comes out]
+- **Input**: <concrete data, not a placeholder>
+- **Output**: <concrete data>
+- **Flow**:
+  1. <step>
+  2. <step>
 
 ## Data Model
 
 ### Entities
 
+<Table per entity if the feature stores or transmits structured data. Omit if not applicable and say so explicitly.>
+
 | Entity | Fields | Description |
 |--------|--------|-------------|
-| [Name] | [field]: [type] | [description] |
+| <Name> | <field>: <type> | <description> |
 
 ### Relationships
 
-```
-[EntityA] ──1:N──> [EntityB]
-```
+<ASCII or text. Example: User --1:N--> Session. Omit if there's only one entity.>
 
 ## Out of Scope
 
-- [What this spec does NOT cover]
-- [What belongs in a different spec]
+<List what this spec deliberately does NOT cover. This is where you put adjacent features that belong in a different spec.>
+
+- <out-of-scope item 1>
+- <out-of-scope item 2>

--- a/.agent/modes/default/templates/task.md
+++ b/.agent/modes/default/templates/task.md
@@ -1,32 +1,39 @@
----
-spec: <TopicName>
-created: <DateTime>
-status: pending
-date: <Date>
----
+<!--
+Template for <topic>_task.md, read via:
+  read_asset { topic: "templates", asset_type: "task" }
+
+Replace every <…> marker. Do not commit literal `<TopicName>` or `<task text>`. The MCP server prepends frontmatter (spec, short, status, date) automatically — omit the `---` block when passing this body as `task_content` to `spec_add`.
+
+Rule: implementation tasks only. Test tasks are appended later in BUILD via task_write, never here in SPEC.
+-->
 
 # Tasks: <TopicName>
 
 ## Implementation
 
 ### Phase 1: Foundation
-- [ ] **1.1** [Foundation task]
+
+- [ ] **1.1** <concrete foundation task — set up a module, add a migration, scaffold a route. Specific enough that a developer can start.>
 
 ### Phase 2: Core Features
-- [ ] **2.1** [Core feature task]
+
+- [ ] **2.1** <concrete core task>
 
 ### Phase 3: Integration
-- [ ] **3.1** [Integration task]
+
+- [ ] **3.1** <concrete integration task: wire components together, expose to callers>
 
 ### Phase 4: Polish
-- [ ] **4.1** [Polish task]
+
+- [ ] **4.1** <concrete polish task: logging, error messages, edge cases>
 
 ## Notes
 
-<!-- Implementation notes, decisions, and blockers -->
-
 <!--
-Date format: YYYY-MM-DD
-Example:
-**2024-01-15**: Chose approach A over B because X
+Use this block during /build to record decisions that aren't in the spec.
+
+Format:
+  **YYYY-MM-DD**: <decision>
+    Reason: <why>
+    Alternative: <what was rejected>
 -->

--- a/.agent/modes/default/templates/topic.md
+++ b/.agent/modes/default/templates/topic.md
@@ -1,27 +1,30 @@
----
-title: <TopicName>
-short: <Add a one-liner description here>
-created: <DateTime>
-modified: <DateTime>
-author: <Author>
----
+<!--
+Template for topic.md, read via:
+  read_asset { topic: "templates", asset_type: "topic" }
+
+Replace every <…> marker with real content. Do not commit `<TopicName>` etc. — those exist only to be replaced. The MCP server prepends frontmatter automatically, so omit the leading `---` block when you pass this body as the `content` argument to `topics_add`.
+
+Required: Overview is the only section that must be non-empty. Sub-topics and Notes may be empty.
+-->
 
 # <TopicName>
 
 ## Overview
 
-> Short description: What is this topic?
+<2-4 sentences describing what this topic covers and why it exists. Keep it concrete; avoid marketing copy.>
 
 ## Specs
 
-List of specs in this topic:
-- `xxx_spec.md`: [Description]
-- `yyy_spec.md`: [Description]
+<List the spec files belonging to this topic. Each spec is created via spec_add and lives next to this file.>
+
+- `<TopicName>_spec.md`: <one-line summary of what this spec covers>
 
 ## Sub-topics
 
-- [sub-topic name]
+<List nested topics. Each appears as `<TopicName>/<sub>` and has its own topic.md/spec/task. Remove this section if there are none.>
+
+- <sub-topic name>
 
 ## Notes
 
-<!-- Additional notes about this topic -->
+<Anything that doesn't fit above: open questions, links to external context, decisions logged later. Free-form. Date entries when relevant.>

--- a/.agent/modes/default/workflows/build.md
+++ b/.agent/modes/default/workflows/build.md
@@ -1,77 +1,110 @@
-# Workflow: /build
+# Workflow: /build (default mode)
 
-## Purpose
-Build topics from Staging. Topic MUST be listed in area queue.md to be pushable.
+Implement a topic — write code into `src/`, link every file, flip task checkboxes, push to Testing.
 
-## Key Requirements
-1. **CREATE /src FIRST** - Before writing any code, create /src at project root
-2. **ALL source files in /src** - At project root, NOT in topic directories
-3. **MUST be in queue** - Topic must be listed in area's queue.md to be pushable
-4. **Check off tasks** - After completing each task, mark it complete in task.md
-5. **Add testing tasks last** - Add test tasks AFTER building, before Testing
-6. **queue.md deleted at Testing** - Normal behavior
+Mirrors `.agent/workflows/build.md`; this file is the per-mode copy.
 
-## Queue File Location
+---
 
-**The queue.md is in the AREA ROOT, not in topic folders:**
-```
-spec/
-├── Staging/
-│   └── queue.md    ← List of topics ready to push
-├── Working/
-│   └── queue.md    ← What to build next
-└── ...
-```
+## Preconditions
 
-## Readiness Rule
+- Topic has `<topic>_spec.md` and `<topic>_task.md` in `spec/Staging/<topic>/`.
+- Topic appears in `spec/Staging/queue.md` (verify via `queue_check`).
+- `src/` exists at the project root.
 
-**Only topics listed in area queue.md can be pushed.**
+If any precondition fails, run `/spec` and `queue_add` first.
 
-Check:
-```
-queue_check {topic: "<topic-name>", area: "Staging"}
-```
+---
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `topics_list`, `queue_list`, `queue_check` | Orient. |
+| `queue_add` | Add topic to `Staging/queue.md` if missing. |
+| `topics_push` | Move between areas. |
+| `unispec_read_spec`, `read_asset` | Load spec / re-read task. |
+| `tasks_list` | Get task indices. |
+| `task_status` | Update `status:` to `working` / `complete`. |
+| `tasks_complete`, `tasks_incomplete` | Flip checkbox at 0-based index. |
+| `index_add` | Link each new file with `link_type: "implementation"`. |
+| `notes_add` | Capture decisions not in the spec. |
+| `task_write` | Append test tasks at the end of BUILD. |
+
+---
 
 ## Steps
 
-### 1. Check Readiness - MUST be in queue
-- Topic must be listed in Staging/queue.md
-- Add to queue if not: `queue_add {topic, area: "Staging"}`
+1. **Orient.**
+   ```
+   topics_list  { area: "Staging" }
+   queue_check  { topic: "<topic>", area: "Staging" }
+   ```
+   If `ready: false`, `queue_add { topic, area: "Staging" }`, then re-check.
 
-### 2. Create /src First
-- System creates this automatically when pushing to Working
-- All code goes in /src at project root
+2. **Push to Working.**
+   ```
+   topics_push { topic: "<topic>", area: "Working" }
+   ```
 
-### 3. Push Topic to Working
-- Push topic that is listed in queue
-- Do this ONE TOPIC AT A TIME
+3. **Load context.**
+   ```
+   unispec_read_spec { topic: "<topic>", area: "Working" }
+   tasks_list        { topic: "<topic>", area: "Working" }
+   task_status       { topic: "<topic>", area: "Working", status: "working" }
+   ```
 
-### 4. Build in Working
-- Work through queue in ORDER
-- Create code in /src
-- Link every file to spec
-- **CHECK OFF EVERY TASK** - Mark complete as you go
+4. **For each open task at index `N`**, in order:
+   1. Write code into `src/<file>`.
+   2. `index_add { topic, path: "src/<file>", link_type: "implementation", tags: "<…>", annotation: "<…>" }`.
+   3. `tasks_complete { topic, task_index: N }`.
+   4. If a decision wasn't in the spec, `notes_add { topic, note: "<decision + reason>" }`.
 
-### 5. Add Testing Tasks Before Testing
-- **ONLY add testing tasks here** - AFTER all implementation is done
-- This is the LAST step before Testing
-- Testing tasks are created in the BUILD phase only, not during SPEC phase
+5. **Append test tasks.**
+   ```
+   read_asset { topic: "<topic>", asset_type: "task", area: "Working" }
+   task_write {
+     topic: "<topic>",
+     area: "Working",
+     content: "<existing body + ### Phase 5: Testing block of `- [ ]` items>"
+   }
+   ```
 
-### 6. Push to Testing
-- When done, push to Testing
-- queue.md automatically deleted
+6. **Promote.**
+   ```
+   task_status { topic: "<topic>", area: "Working", status: "complete" }
+   topics_push { topic: "<topic>", area: "Testing" }
+   ```
 
-## File Placement
+---
+
+## File layout
 
 ```
-PROJECT ROOT/
-├── src/                    <-- ALL CODE HERE
-└── spec/                   <-- Specs here (NOT code)
+<project-root>/
+├── src/                     # all code
+└── spec/
+    └── <Area>/<topic>/{topic.md, <topic>_spec.md, <topic>_task.md}
 ```
 
-## Important Notes
+Nested topic `auth/login` → `spec/<Area>/auth/login/auth-login_spec.md` and `auth-login_task.md`.
 
-- **Check off each task** - Don't skip! Mark tasks complete immediately
-- **Queue is in area root** - Not in topic folders
-- **Testing comes last** - Add test tasks after all implementation done
-- **NO testing in spec phase** - Only development tasks during SPEC workflow
+---
+
+## Definition of done
+
+- Every implementation task is `- [x]`.
+- `task_status` is `complete`.
+- Every file you wrote/changed in `src/` has an `index_add` entry.
+- Decisions outside the spec are recorded via `notes_add`.
+- A test-tasks section has been appended via `task_write`.
+- `topics_push { area: "Testing" }` succeeded.
+
+---
+
+## Failure modes
+
+- **`topics_push` rejected** — topic not in `Staging/queue.md`. Run `queue_add`.
+- **`task_write` rejected** — no spec exists. Run `/spec` first.
+- **`tasks_complete` says index missing** — re-run `tasks_list`; indices recompute after any edit.
+- **Wrote code outside `src/`** — move it, or document via `notes_add` why it lives elsewhere.

--- a/.agent/modes/default/workflows/ingest.md
+++ b/.agent/modes/default/workflows/ingest.md
@@ -1,20 +1,56 @@
-# Workflow: /ingest-all
+# Workflow: /ingest-all (default mode)
 
-## Purpose
-Analyze a codebase bottom-up, starting from a user-defined entry point, and generate a complete spec tree.
+Reverse-engineer an existing codebase into a spec tree under the `Ingested` area. See `.agent/workflows/ingest.md` for the full workflow — this file mirrors it for the default mode.
 
-## Process
-1. **Analyze**: Use `unispec parse` on the starting directory to extract functions, structs, and enums.
-2. **Map**: Use `unispec index callers` to identify relationships between files and symbols.
-3. **Synthesize**:
-   - Create a Topic for the current module.
-   - Generate `topic.md` (with a one-liner description).
-   - Generate `spec.md` (describing existing functionality).
-   - Generate `task.md` (marking implementation as complete).
-4. **Recurse**: Move to sub-directories and repeat until the entire tree is mapped.
+---
 
-## Agent Rules
-- Do not modify existing code.
-- If you encounter a complex dependency, use `unispec index callers` to map the relationship.
-- If a directory is already mapped, skip it.
-- Ensure every generated spec is bound to the relevant file using `unispec index add`.
+## Tools
+
+CLI:
+- `unispec ingest run <path> [-a <area>] [-t <topic>] [-l <langs>]`
+- `unispec parse file <path> [--item-type functions|structs|enums|imports|all] [--json]`
+- `unispec index add --topic <name> --path <path>`
+- `unispec index callers <symbol>` (CLI only — not an MCP tool)
+
+MCP:
+- `topics_add { topic, area, short, content }`
+- `spec_add { topic, area, short, spec_content, task_content }`
+- `index_add { topic, path, link_type, tags?, annotation? }`
+- `notes_add { topic, note }`
+
+---
+
+## Steps
+
+1. **Bulk ingest:**
+   ```bash
+   unispec ingest run <path> -a Ingested -t <topic-prefix>
+   ```
+   Writes parsed code analysis to `spec/code_analysis.toml` (or markdown, per `[ingest].output_format`).
+
+2. **Create a topic per module** with real Overview / Purpose / Sub-topics in `content`. Set `short` to a real one-liner.
+
+3. **Write the spec from the parsed surface.** Every public function/type appears as a `REQ-*` row referencing `<file>:<line>`. The task file is all `- [x]` because the code already exists.
+
+4. **Link every source file** with `index_add` (`link_type: "implementation"`, tag with the language and `ingested`).
+
+5. **Capture cross-module dependencies** via `unispec index callers <symbol>` and record them with `notes_add` on the dependent topic.
+
+6. **Recurse** through sub-directories. Skip directories with no supported source or that are already represented in `topics_list { area: "Ingested" }`.
+
+---
+
+## Definition of done
+
+- Every supported source directory has a topic with topic/spec/task files.
+- Every source file appears in `index_list` linked to its topic.
+- Cross-module dependencies are captured via `notes_add` on dependents.
+- No source code was modified.
+
+---
+
+## Agent rules
+
+- Do not modify source code.
+- Every `REQ-*` must cite real existing behavior at `<file>:<line>`. No invented requirements.
+- For unclear functions, write "TODO: clarify purpose" and open the question via `notes_add` — don't guess.

--- a/.agent/modes/default/workflows/test.md
+++ b/.agent/modes/default/workflows/test.md
@@ -1,17 +1,82 @@
-# Workflow: /test
+# Workflow: /test (default mode)
 
-## Purpose
-Run build scripts, test suites, and security checks to verify the implementation.
+Run the project's build/test pipeline for a topic in `Testing`. Promote on green; route to `Fixing` on red. This workflow does not modify code.
 
-## Process
-1. **Context Loading**: Identify the topic and area using `unispec_nav`.
-2. **Build Execution**: Run the configured build command via `unispec_auto_build`.
-3. **Test Execution**: Run the configured test command via `unispec_auto_test`.
-4. **Verification**: 
-   - If successful: Report success and prompt for promotion to Build.
-   - If failed: Report errors, identify the failing test/build, and suggest running `unispec_auto_verify --fix`.
+Mirrors `.agent/workflows/test.md`; per-mode copy.
 
-## Agent Instructions
-- Use `unispec_auto_test` to execute the pipeline.
-- If the build fails, do not attempt to fix it automatically. Report the error and wait for the user to trigger `unispec_auto_verify --fix`.
-- Ensure all test output is captured in the report.
+---
+
+## Tools
+
+MCP:
+- `topics_list { area: "Testing" }`
+- `unispec_read_spec { topic, area: "Testing" }`
+- `notes_add { topic, note }`
+- `topics_push { topic, area }`
+- `task_status { topic, area, status }`
+- `unispec_<connector>` — one MCP tool per connector defined in `.agent/config.toml` (e.g. `unispec_test`, `unispec_build`).
+
+CLI (shell out):
+- `unispec auto test [-t <topic>] [--pre-script …] [--post-script …]`
+- `unispec connector run <name>` (equivalent to the dynamic MCP tool)
+
+There is no `unispec_auto_test` MCP tool; use the configured connector or shell out.
+
+---
+
+## Steps
+
+1. **Identify the topic.**
+   ```
+   topics_list       { area: "Testing" }
+   unispec_read_spec { topic: "<topic>", area: "Testing" }
+   ```
+
+2. **Run the pipeline.** Prefer configured connectors via MCP:
+   ```
+   unispec_build { args: [] }
+   unispec_test  { args: [] }
+   ```
+   Or shell out:
+   ```bash
+   unispec auto test -t <topic>
+   ```
+   Capture exit code and combined output.
+
+3. **Report.**
+   ```
+   notes_add {
+     topic: "<topic>",
+     note: "Test run YYYY-MM-DD: build=<pass|fail> test=<pass|fail>\n<first 20 lines of failing output, if any>"
+   }
+   ```
+
+4. **Route.**
+   - All green:
+     ```
+     task_status { topic: "<topic>", area: "Testing", status: "complete" }
+     topics_push { topic: "<topic>", area: "Build" }
+     ```
+   - Any red:
+     ```
+     topics_push { topic: "<topic>", area: "Fixing" }
+     task_status { topic: "<topic>", area: "Fixing", status: "working" }
+     ```
+     Do not attempt to fix code in `/test`. Hand off to `/verify --fix`.
+
+---
+
+## Definition of done
+
+- Every configured step (build, test, optionally lint/typecheck) ran for the topic.
+- Each step's result was recorded via `notes_add`.
+- The topic was pushed to `Build` (all green) or `Fixing` (any red).
+- `task_status` matches the new area: `complete` for Build, `working` for Fixing.
+
+---
+
+## Failure modes
+
+- **Connector not found** — verify with `unispec connector list`. If missing, fall back to shelling out — but ask the user first.
+- **Connector timed out** — the exit code reflects the timeout, not a true failure. Mention this in the note and pause for user input before routing.
+- **No connectors at all** — read the spec for a manual test plan, execute it, and report via `notes_add`.

--- a/.agent/modes/default/workflows/unispec:spec.md
+++ b/.agent/modes/default/workflows/unispec:spec.md
@@ -1,56 +1,96 @@
-# Workflow: unispec:spec
+# Workflow: unispec:spec (default mode)
 
-**Constraint: Use this command ONLY for generating specs and tasks following templates exactly.**
-
-## Purpose
-**Act as a UniSpec Specification Architect.** Your goal is to create precise, actionable specs and tasks using the system templates.
-
-## CRITICAL: Use MCP Tools with Template Content!
-
-**Constraint: ALWAYS use MCP tools (topics_add, spec_add) with content parameters matching the templates - NEVER create empty files!**
-
-- Use `topics_add {topic, area, short: "...", content: "..."}` - creates topic WITH full content and short description
-- Use `spec_add {topic, area, short: "...", spec_content: "...", task_content: "..."}` - creates spec AND task WITH full content
-
-**IMPORTANT**: Both `content` (20+ chars) and `short` parameters are REQUIRED!
-
-## Execution Protocol
-
-When the Architect Agent determines that a specification is sufficiently refined, it will trigger this workflow.
-
-### 1. Pre-Execution Validation
-- **Context Check**: Ensure the Topic and Area have been clearly defined during the Architectural Discovery phase. If not, please ask the user any questions you may have before generating specs.
-- **Template Verification**: Confirm that the required templates exist in `/.agent/modes/default/templates/`.
-- **Path Constraint**: All generated artifacts MUST be placed within the `/spec/staging` directory.
-
-### 2. Artifact Generation Using Templates
-**Constraint: Follow the templates EXACTLY - do not deviate!**
-
-The command performs the following operations:
-- **Directory Creation**: Creates a new directory under `/spec/staging/<topic_name>`.
-- **Spec Generation**: Populates `<spec_name>_spec.md` inside the `<topic_name>` directory using the EXACT template from `/.agent/modes/default/templates/spec.md`. 
-- **Task Generation**: Populates `<spec_name>_task.md` inside the same `<topic_name>` directory as the spec using the EXACT template from `/.agent/modes/default/templates/task.md`.
-- **Constraint: NO TESTING TASKS** - Only create IMPLEMENTATION tasks in task.md. Testing is handled in the BUILD phase.
-
-### 3. Post-Execution
-- **Confirmation**: The system returns a success message confirming the path of the created artifacts.
-- **Transition**: The agent moves the project state from "Architectural Discovery" to the "Staging" area.
-- **Handover**: The agent instructs the user to begin the implementation phase based on the generated `task.md`.
+Create a topic, spec, and task list in `Staging` using the MCP tools. This is the spec-authoring command for the default mode.
 
 ---
 
-## CRITICAL: NO TESTING TASKS!
+## Preconditions
 
-**Constraint: NEVER create testing tasks during SPEC workflow!**
+- You have a one-line description of the feature (`short`).
+- You have enough information to write real content for the topic, spec, and task list — no `[placeholder]` strings.
 
-Testing tasks are ONLY added in the BUILD phase, right before pushing to Testing.
-
-- ❌ DO NOT add: "write tests", "run tests", "test functionality", "verify with tests"
-- ✅ DO add: implementation tasks like "implement feature", "create module", "add API endpoint"
+If either is missing, ask the user before doing anything.
 
 ---
 
-## Error Handling
-- **Duplicate Prevention**: If a directory for the specified topic already exists in the target area, the command must abort and report the conflict.
-- **Template Missing**: If a template file is missing, the command must use a hardcoded default fallback and notify the user.
-- **Permission Denied**: Any attempt to write outside of the `/spec` directory must be blocked by the system.
+## Tools
+
+| Tool | Required args | Notes |
+|------|---------------|-------|
+| `read_asset` | `topic, asset_type` | Read templates with `topic: "templates"`, `asset_type ∈ {"topic","spec","task"}`. |
+| `topics_add` | `topic, area, short, content` | `content` ≥ 10 chars. Server prepends frontmatter — don't include `---`. |
+| `spec_add` | `topic, area, short, spec_content, task_content` | Both content fields ≥ 10 chars. Creates `<topic>_spec.md` and `<topic>_task.md`. |
+| `queue_add` | `topic, area` | Add to `spec/Staging/queue.md`. |
+| `topics_show` | `topic, area` | Verify the files exist. |
+
+---
+
+## Steps
+
+### 1. Read the templates
+```
+read_asset { topic: "templates", asset_type: "topic" }
+read_asset { topic: "templates", asset_type: "spec" }
+read_asset { topic: "templates", asset_type: "task" }
+```
+
+### 2. Create the topic
+```
+topics_add {
+  topic: "<topic-name>",
+  area: "Staging",
+  short: "<one-line description>",
+  content: "<body mirroring templates/topic.md, with real content>"
+}
+```
+
+### 3. Create the spec and tasks
+```
+spec_add {
+  topic: "<topic-name>",
+  area: "Staging",
+  short: "<one-line description>",
+  spec_content: "<body mirroring templates/spec.md, every section filled>",
+  task_content: "<body mirroring templates/task.md, implementation tasks only>"
+}
+```
+
+Filenames produced: `<topic>_spec.md`, `<topic>_task.md` (slashes/spaces in `topic` become `-`).
+
+### 4. Add to the readiness queue
+```
+queue_add { topic: "<topic-name>", area: "Staging" }
+```
+
+### 5. Verify
+```
+topics_show { topic: "<topic-name>", area: "Staging" }
+```
+Expect to see `topic.md`, `<topic>_spec.md`, `<topic>_task.md`.
+
+---
+
+## Content rules
+
+- **Spec = WHAT, not HOW.** Use SHALL/SHOULD; acceptance criteria are checkable.
+- **Tasks = implementation steps only.** No test tasks here.
+- **No placeholder text in the body.** `[Requirement statement]`, `[Foundation task]`, etc. exist in the template to be replaced.
+- **Nested topics use `/`** (e.g., `auth/login`). The parent topic must already exist.
+
+---
+
+## Definition of done
+
+- `spec/Staging/<topic>/topic.md` exists with real content.
+- `spec/Staging/<topic>/<topic>_spec.md` exists with every template section filled.
+- `spec/Staging/<topic>/<topic>_task.md` exists with concrete implementation tasks and zero test tasks.
+- `queue_check { topic, area: "Staging" }` returns `ready: true`.
+
+---
+
+## Failure modes
+
+- **`topics_add` errors with "content required"** — `content` was empty or under 10 chars. Write a real body.
+- **`spec_add` errors with "spec_content required"** — you passed `content` instead. Use `spec_content`.
+- **`spec_add` errors with "parent topic does not exist"** — for a nested topic like `auth/login`, run `topics_add { topic: "auth", ... }` first.
+- **Conflict on existing topic** — `topics_add` refuses to overwrite. If you genuinely want to redo it, `topics_delete { topic, force: true }` first.

--- a/.agent/modes/default/workflows/verify.md
+++ b/.agent/modes/default/workflows/verify.md
@@ -1,27 +1,87 @@
-# Workflow: /verify
+# Workflow: /verify (default mode)
 
-## Purpose
-Verify the alignment between the specification and the implementation. This workflow can be triggered at any stage to ensure quality and consistency.
+Confirm that the implementation in `src/` satisfies every requirement in the spec. With `--fix`, repair gaps and return to Testing.
 
-## Process
-1. **Context Loading**:
-   - Use `unispec_read_spec` to load `spec.md` and `task.md` for the current topic.
-   - Use `unispec_nav` to identify bound files.
+Mirrors `.agent/workflows/verify.md`; per-mode copy.
 
-2. **Alignment Check**:
-   - Execute `unispec_auto_verify` with the topic name.
-   - Analyze the output for mismatches between requirements and implementation.
+---
 
-3. **Relationship Check**:
-   - Use `unispec_query_relations` for key functions to ensure no regressions were introduced in dependent modules.
+## Tools
 
-4. **Fixing (If --fix tag is present)**:
-   - If issues are found, move the topic to the `Fixing` area.
-   - Analyze failure logs or alignment issues.
-   - Apply fixes to the code using `file_write`.
-   - Update `task.md` notes using `unispec_update_task` with the fix details.
-   - Return to `Testing` area.
+MCP:
+- `unispec_read_spec { topic, area }`
+- `read_asset { topic, asset_type: "spec", area }`
+- `index_list { topic }`
+- `index_find { query, by }` — `by ∈ {"topic","path","tag"}`
+- `index_backlinks { topic }`
+- `notes_add { topic, note }`
+- `topics_push { topic, area }`
+- `task_status { topic, area, status }`
 
-5. **Reporting**:
-   - Update `topic.md` with the verification status (aligned/misaligned).
-   - If misaligned, list specific issues in the `Verification Summary` section.
+CLI:
+- `unispec auto verify <topic>` — runs the configured verifier.
+
+There is no MCP tool named `unispec_auto_verify`, `unispec_query_relations`, `unispec_update_task`, or `unispec_nav`. Use the tools listed above.
+
+---
+
+## Steps
+
+1. **Load context.**
+   ```
+   unispec_read_spec { topic: "<topic>", area: "<Testing or Working>" }
+   index_list        { topic: "<topic>" }
+   ```
+
+2. **Trace each requirement.** For every `REQ-*` in the spec:
+   - Find the linked file(s) from `index_list` (filter `link_type: "implementation"`).
+   - Read the file(s) with the host editor's Read tool.
+   - Record state: `✓ implemented`, `⚠ partial`, or `✗ missing`. Always cite `<file>:<line>`.
+
+3. **Run the verifier (optional).**
+   ```bash
+   unispec auto verify <topic>
+   ```
+   Combine its output with your manual trace.
+
+4. **Scope regressions.**
+   ```
+   index_backlinks { topic: "<topic>" }
+   ```
+   For each dependent topic, re-check its critical paths.
+
+5. **Report.**
+   ```
+   notes_add {
+     topic: "<topic>",
+     note: "Verification YYYY-MM-DD: <N>/<M> requirements implemented.\n- REQ-001 ✓ src/auth/login.rs:42\n- REQ-002 ✗ not found\n- REQ-003 ⚠ partial — src/auth/login.rs:88 (locks after 10 failures, spec says 5)"
+   }
+   ```
+
+6. **With `--fix`, if gaps exist:**
+   ```
+   topics_push { topic: "<topic>", area: "Fixing" }
+   task_status { topic: "<topic>", area: "Fixing", status: "working" }
+   ```
+   Fix in `src/`, flip checkboxes (`tasks_complete`), record decisions (`notes_add`), then:
+   ```
+   topics_push { topic: "<topic>", area: "Testing" }
+   task_status { topic: "<topic>", area: "Testing", status: "complete" }
+   ```
+
+---
+
+## Definition of done
+
+- Every `REQ-*` in the spec has a recorded state (`✓` / `⚠` / `✗`) with `<file>:<line>` evidence.
+- The verification block is appended via `notes_add`.
+- With `--fix`: gaps closed, topic back in `Testing`, `task_status` is `complete`.
+- Without `--fix`: gaps reported by `REQ-*` ID; the topic stays where it is.
+
+---
+
+## Failure modes
+
+- **`unispec_read_spec` returns empty content** — wrong area, or files were renamed manually. Run `topics_show { topic, show_all: true }` to locate them.
+- **`index_list` returns nothing** — code exists but was never linked. Catch up with `index_add` and report the gap as a BUILD-process failure.
+- **Verifier exits non-zero with no per-REQ mapping** — don't auto-push to Fixing. Ask the user how to interpret the failure.

--- a/.agent/skill.md
+++ b/.agent/skill.md
@@ -1,40 +1,67 @@
 # Skill: UniSpec Architect Orchestrator
 
 ## Persona
-You are a Senior Software Architect. Your expertise spans deep system design, complex data structures, and robust software engineering principles. You are the strategic partner for the user, focused on clarity, structure, and technical excellence.
 
-## Core Objective
-Your goal is to guide the user from an abstract idea to a concrete, implementation-ready specification. You do NOT write code, specs, or tasks yourself. You facilitate, analyze, and refine until the user's vision is architecturally sound and the user runs the `unispec:spec` command.
+You are a Senior Software Architect. You partner with the user to move ideas from concept to a concrete, implementable specification. You think in data structures, system boundaries, and trade-offs.
 
-## Operational Constraints
-- **Strictly No Writing**: You are forbidden from creating, modifying, or deleting any files. You are forbidden from generating `spec.md`, `topic.md`, or `task.md` files.
-- **No File Operations**: You are explicitly prohibited from performing any file system operations. Any request to create or edit a file must be refused.
-- **Architectural Focus**: Focus exclusively on data structures, system architecture, and logic.
-- **Clarification Loop**: Ask targeted, step-by-step questions. Do not assume requirements. If a detail is vague, force clarification.
-- **Bullet-Point Enforcement**: All architectural consultations, questions, and summaries MUST be formatted using bullet points to ensure consistency and ease of parsing.
-- **Project Awareness**: Before engaging, analyze the current state of the project (`/spec`, `/src`, and existing `topic.md` files) to understand the current context and pipeline.
-- **Template Awareness**: Reference the templates in `/.agent/modes/default/templates/` to ensure the user's requirements align with the project's expected structure.
+## Core objective
 
-## Workflow Protocol
-1. **Discovery**: Analyze the existing project structure to understand what is built and what is planned.
-2. **Consultation**: Ask questions to extract the Functional Goal, Data Structures, and Scope Boundaries using bullet points.
-3. **Refinement**: Help the user structure their thoughts into organized Topics and Specs. Encourage the creation of multiple specs/topics to maintain high organization.
-4. **Verification**: Once you believe the requirements are sufficiently detailed and ready for implementation, instruct the user to execute the `unispec:spec` command. If you are ready, run the `unispec:spec` command, or if there is something else you would like me to know, please feel free to share.
+Drive the user from an abstract idea to a `/spec`-ready specification. You **do not** write production code. You facilitate, clarify, and refine. When the requirements are clear enough, you invoke the spec creation tools (`topics_add`, `spec_add`) — or instruct the user to run `/spec`.
 
-## Actionable Steps
-1. **List Specs/Requirements**: Summarize the current understanding of the project's specs and requirements to ensure alignment with the user's vision.
-2. **Clarify via Questions**: Ask targeted questions using a numbered bullet-point format to refine specifications and architectural strategies.
-3. **Finalize**: Confirm readiness and instruct the user to execute the `unispec:spec` command to proceed with implementation.
+## Operational constraints
 
-## Area Awareness
-You are currently in the **Architectural Discovery** phase. You must monitor the `area.md` file to understand the current lifecycle stage of the project:
-- **Staging**: Creating specs.
-- **Working**: Actively building/refining.
-- **Testing**: Running build scripts/verification.
-- **Fixing**: Debugging/feedback loop.
-- **Build**: Ready for shipping.
+- **No code in `src/`.** Anything that lives under `src/` is the job of `/build`, not architectural discovery.
+- **Use MCP tools for spec artifacts.** Do not write `topic.md`, `*_spec.md`, or `*_task.md` with the host editor's Write tool — call `topics_add`, `spec_add`, `spec_write`, `task_write` so the server can manage frontmatter, filenames, and area conventions correctly.
+- **Architectural focus.** Stay on data structures, system architecture, and explicit trade-offs.
+- **Clarify, don't assume.** If a requirement is vague, ask one targeted follow-up. Don't fabricate.
+- **Project awareness.** Before engaging, run:
+  ```
+  areas_list
+  topics_list { area: "Staging" }
+  topics_list { area: "Working" }
+  ```
+  and read existing `topic.md` / `*_spec.md` via `read_asset` or `unispec_read_spec`.
+- **Template awareness.** Reference templates in `.agent/modes/default/templates/` via:
+  ```
+  read_asset { topic: "templates", asset_type: "topic" }
+  read_asset { topic: "templates", asset_type: "spec" }
+  read_asset { topic: "templates", asset_type: "task" }
+  ```
+  Mirror the section headings exactly; never commit `[placeholder]` text.
 
-## Interaction Style
-- **Imperative & Clear**: Use clear, professional, and concise language.
-- **Logical**: Think step-by-step.
-- **Supportive but Firm**: Act as a cheerleader for the user's vision, but remain a strict gatekeeper for architectural quality.
+## Workflow protocol
+
+1. **Discover.** Use the orientation tools above to map what already exists.
+2. **Consult.** Ask the user — in numbered bullet points — about the functional goal, the data model, and the scope boundary.
+3. **Refine.** Organize the user's responses into one topic per bounded scope. Encourage splitting into nested sub-topics when scope grows.
+4. **Commit.** When the user confirms the spec is complete, run `topics_add` and `spec_add` (or invoke `/spec` and let it run them). Confirm both files exist with `topics_show`.
+
+## Definition of done
+
+The orchestration phase is done when, for each topic the user wanted:
+- The topic has real (non-placeholder) `topic.md`, `<topic>_spec.md`, and `<topic>_task.md` content.
+- The spec contains at least one `REQ-*` row and one example.
+- The task file lists implementation tasks only (no test tasks — those come in `/build`).
+- The topic is registered in `spec/Staging/queue.md` via `queue_add`.
+- `queue_check { topic, area: "Staging" }` returns `ready: true`.
+
+## Area awareness
+
+Topics move through these areas in order:
+
+| Area | Stage | What you do here |
+|------|-------|------------------|
+| Staging | Spec writing | Use `topics_add`, `spec_add`. |
+| Working | Implementation | Build code under `src/`; flip task checkboxes. |
+| Testing | Verification | Run tests; route to Build (green) or Fixing (red). |
+| Fixing | Debugging | Repair gaps; return to Testing. |
+| Build | Shipped | Treat as immutable. |
+
+`/skill` operates almost entirely in `Staging`.
+
+## Interaction style
+
+- **Imperative & clear.** Direct, professional, concise.
+- **Logical.** Step-by-step. State assumptions explicitly.
+- **Supportive but firm.** Cheerlead the user's vision; gatekeep architectural quality.
+- **Bullet points by default.** Consultation, questions, and summaries are bulleted unless prose is genuinely clearer.

--- a/.agent/workflows/build.md
+++ b/.agent/workflows/build.md
@@ -1,90 +1,153 @@
 # Workflow: /build
 
-## Purpose
-Build topics from Staging. Topic MUST be listed in area queue.md to be pushable.
+Implement a topic from Staging — write code into `src/`, link every file, flip task checkboxes, and push to Testing.
 
-## Key Requirements
-1. **CREATE /src FIRST** - Before writing any code, create /src at project root
-2. **ALL source files in /src** - At project root, NOT in topic directories
-3. **MUST be in queue** - Topic must be listed in area's queue.md to be pushable
-4. **Check off tasks** - After completing each task, mark it complete in task.md
-5. **Add testing tasks last** - Add test tasks AFTER building, before Testing
-6. **queue.md deleted at Testing** - Normal behavior
-7. **Use read_asset** to read topic.md, spec, or task files during build
+This workflow uses the UniSpec MCP tools. Tool names are literal.
 
-## Read Asset Tool
+---
 
-Use `read_asset` to read any file:
+## Preconditions
 
-```
-read_asset {
-  topic: "myproject/auth",
-  asset_type: "spec",   // "topic", "spec", or "task"
-  area: "Working"
-}
-```
+- The topic has both files: `<topic>_spec.md` and `<topic>_task.md` in `spec/Staging/<topic>/` (verify with `topics_show`).
+- The topic is in `spec/Staging/queue.md` (verify with `queue_check`).
+- `src/` exists at project root (create it once if not).
 
-## Queue File Location
+If any precondition fails, run `/spec` for the topic first, then `queue_add`.
 
-**The queue.md is in the AREA ROOT, not in topic folders:**
-```
-spec/
-├── Staging/
-│   └── queue.md    ← List of topics ready to push
-├── Working/
-│   └── queue.md    ← What to build next
-└── ...
-```
+---
 
-## Readiness Rule
+## Tools
 
-**Only topics listed in area queue.md can be pushed.**
+| Tool | Purpose |
+|------|---------|
+| `topics_list`, `queue_list`, `queue_check` | Orient. |
+| `queue_add` | Register the topic if it's missing from `Staging/queue.md`. |
+| `topics_push` | Move the topic between areas. |
+| `unispec_read_spec` | Load spec + task content in one call. |
+| `read_asset` | Re-read the task file when you need its current state. |
+| `tasks_list` | Get task indices and checkbox state. |
+| `task_status` | Update frontmatter `status:` to `working` / `complete`. |
+| `tasks_complete` / `tasks_incomplete` | Flip `- [ ]` / `- [x]` at a 0-based index. |
+| `index_add` | Link each new file to the topic. |
+| `notes_add` | Capture decisions that aren't in the spec. |
+| `task_write` | Used once to append test tasks before pushing to Testing. |
 
-Check:
-```
-queue_check {topic: "<topic-name>", area: "Staging"}
-```
+---
 
 ## Steps
 
-### 1. Check Readiness - MUST be in queue
-- Topic must be listed in Staging/queue.md
-- Add to queue if not: `queue_add {topic, area: "Staging"}`
-
-### 2. Create /src First
-- System creates this automatically when pushing to Working
-- All code goes in /src at project root
-
-### 3. Push Topic to Working
-- Push topic that is listed in queue
-- Do this ONE TOPIC AT A TIME
-
-### 4. Build in Working
-- Work through queue in ORDER
-- Create code in /src
-- Link every file to spec
-- **CHECK OFF EVERY TASK** - Mark complete as you go
-
-### 5. Add Testing Tasks Before Testing
-- **ONLY add testing tasks here** - AFTER all implementation is done
-- This is the LAST step before Testing
-- Testing tasks are created in the BUILD phase only, not during SPEC phase
-
-### 6. Push to Testing
-- When done, push to Testing
-- queue.md automatically deleted
-
-## File Placement
-
+### 1. Orient
 ```
-PROJECT ROOT/
-├── src/                    <-- ALL CODE HERE
-└── spec/                   <-- Specs here (NOT code)
+topics_list   { area: "Staging" }
+queue_list    { area: "Staging" }
+queue_check   { topic: "<topic>", area: "Staging" }
+```
+If `ready: false`, add to queue:
+```
+queue_add     { topic: "<topic>", area: "Staging" }
+queue_check   { topic: "<topic>", area: "Staging" }   # must now return ready: true
 ```
 
-## Important Notes
+### 2. Push to Working
+```
+topics_push   { topic: "<topic>", area: "Working" }
+```
 
-- **Check off each task** - Don't skip! Mark tasks complete immediately
-- **Queue is in area root** - Not in topic folders
-- **Testing comes last** - Add test tasks after all implementation done
-- **NO testing in spec phase** - Only development tasks during SPEC workflow
+### 3. Load the spec
+```
+unispec_read_spec { topic: "<topic>", area: "Working" }
+tasks_list        { topic: "<topic>", area: "Working" }
+task_status       { topic: "<topic>", area: "Working", status: "working" }
+```
+
+### 4. Implement, one task at a time
+
+For each open task at index `N`:
+
+1. Write code into `src/<file>` (host editor's Write/Edit tool — code files are not managed by MCP).
+2. Link it:
+   ```
+   index_add {
+     topic: "<topic>",
+     path: "src/<file>",
+     link_type: "implementation",
+     tags: "<comma-separated>",
+     annotation: "<one line: what this contributes>"
+   }
+   ```
+3. Flip the checkbox:
+   ```
+   tasks_complete { topic: "<topic>", task_index: N }
+   ```
+4. If the choice you made isn't in the spec:
+   ```
+   notes_add { topic: "<topic>", note: "<decision + reason>" }
+   ```
+
+Do all four for the task before moving to the next index.
+
+### 5. Append test tasks (BUILD phase only)
+
+Test tasks are added now, after implementation, not during SPEC.
+
+```
+read_asset { topic: "<topic>", asset_type: "task", area: "Working" }
+```
+Then call `task_write` with the original content plus a `### Phase 5: Testing` section:
+```
+task_write {
+  topic: "<topic>",
+  area: "Working",
+  content: "<existing task body + new Phase 5 Testing block with `- [ ]` items>"
+}
+```
+`task_write` overwrites the whole file — include the existing implementation phases verbatim.
+
+### 6. Mark complete and push to Testing
+```
+task_status { topic: "<topic>", area: "Working", status: "complete" }
+topics_push { topic: "<topic>", area: "Testing" }
+```
+
+Pushing into Testing deletes `queue.md` in Testing per the mode config — that is expected.
+
+---
+
+## File layout
+
+```
+<project-root>/
+├── src/                      # all code
+└── spec/
+    ├── Staging/
+    │   ├── queue.md
+    │   └── <topic>/{topic.md, <topic>_spec.md, <topic>_task.md}
+    └── Working/
+        └── <topic>/{topic.md, <topic>_spec.md, <topic>_task.md}
+```
+
+Nested topic `auth/login` → directory `spec/<Area>/auth/login/` with `auth-login_spec.md` and `auth-login_task.md`.
+
+---
+
+## Definition of done
+
+A topic is done with BUILD when **all** of these hold:
+
+- Every implementation task in `<topic>_task.md` is `- [x]`.
+- `task_status` is `complete`.
+- Every code file you wrote or substantively changed has a matching `index_add` link with `link_type: "implementation"`.
+- Decisions not in the spec are captured via `notes_add`.
+- A test-tasks section was appended via `task_write`.
+- `topics_push { area: "Testing" }` succeeded.
+
+If any item is missing, the topic is not ready for Testing.
+
+---
+
+## Failure modes
+
+- **`topics_push` rejects the push from Staging** — topic not in `Staging/queue.md`. Run `queue_add`, then `queue_check`.
+- **`task_write` errors with "spec doesn't exist"** — the topic has no `<topic>_spec.md`. Run `/spec` first.
+- **`tasks_complete` errors with "task at index N not found"** — `tasks_list` indices change after any edit; re-list before each `tasks_complete`.
+- **You wrote a file outside `src/`** — fix by moving the file into `src/` or, if intentional, document via `notes_add`.

--- a/.agent/workflows/ingest.md
+++ b/.agent/workflows/ingest.md
@@ -1,20 +1,119 @@
 # Workflow: /ingest-all
 
-## Purpose
-Analyze a codebase bottom-up, starting from a user-defined entry point, and generate a complete spec tree.
+Reverse-engineer an existing codebase into a spec tree. For each module, extract its public surface and create a topic + spec + task set that documents what the code already does.
 
-## Process
-1. **Analyze**: Use `unispec parse` on the starting directory to extract functions, structs, and enums.
-2. **Map**: Use `unispec index callers` to identify relationships between files and symbols.
-3. **Synthesize**:
-   - Create a Topic for the current module.
-   - Generate `topic.md` (with a one-liner description).
-   - Generate `spec.md` (describing existing functionality).
-   - Generate `task.md` (marking implementation as complete).
-4. **Recurse**: Move to sub-directories and repeat until the entire tree is mapped.
+This workflow uses the CLI (`unispec parse`, `unispec ingest run`, `unispec index add`) and the MCP tools (`topics_add`, `spec_add`, `index_add`).
 
-## Agent Rules
-- Do not modify existing code.
-- If you encounter a complex dependency, use `unispec index callers` to map the relationship.
-- If a directory is already mapped, skip it.
-- Ensure every generated spec is bound to the relevant file using `unispec index add`.
+---
+
+## Tools
+
+CLI tools used:
+- `unispec ingest run <path> [-a <area>] [-t <topic>] [-l <langs>]` — bulk ingest a directory; writes to `spec/code_analysis.toml` by default.
+- `unispec parse file <path> [--item-type functions|structs|enums|imports|all] [--json]` — parse a single file.
+- `unispec index add --topic <name> --path <path>` — link a file to a topic (CLI form of `index_add`).
+- `unispec index callers <symbol>` — find references to a symbol (CLI only; not an MCP tool).
+
+MCP tools used:
+- `topics_add { topic, area, short, content }` — create a topic for the module.
+- `spec_add { topic, area, short, spec_content, task_content }` — record the spec and a task list that's already marked complete.
+- `index_add { topic, path, link_type: "implementation" }` — link the source file.
+
+Supported languages for parsing: rust, javascript, typescript, python, go, bash.
+
+---
+
+## Steps
+
+### 1. Run the bulk ingest
+
+```bash
+unispec ingest run <path> -a Ingested -t <topic-prefix>
+```
+
+This produces `spec/code_analysis.toml` (or markdown files, per `[ingest]` config in `.agent/config.toml`) summarizing functions, structs, enums, and imports per file.
+
+### 2. For each module, create a topic
+
+Pick a meaningful boundary (a directory, a package, a Rust module). For each:
+
+```
+topics_add {
+  topic: "<module>",
+  area: "Ingested",
+  short: "<one-line description of what the module does>",
+  content: "# <module>\n\n## Overview\n<2-4 sentences on responsibility>\n\n## Specs\n- <module>_spec.md: existing behaviour\n\n## Sub-topics\n- (one per sub-module)\n\n## Notes\n- Ingested from <path> on YYYY-MM-DD."
+}
+```
+
+### 3. Write the spec from the parsed surface
+
+Use `unispec parse file <path> --json` to extract the file's functions/structs/enums, then:
+
+```
+spec_add {
+  topic: "<module>",
+  area: "Ingested",
+  short: "<one-line description>",
+  spec_content: "# Design: <module>\n\n## Overview\n<what this module does>\n\n## Purpose\n<why it exists>\n\n## In-Depth Details\n<list of public functions/types with signatures>\n\n## Requirements\n| ID | Requirement | Priority |\n|----|-------------|----------|\n| REQ-001 | Module SHALL expose <fn>(<sig>) — currently in <file>:<line>. | Must |\n\n## Data Model\n<structs/enums>\n\n## Out of Scope\n- (anything in adjacent modules)",
+  task_content: "# Tasks: <module>\n\n## Implementation\n\n### Phase 1: Foundation\n- [x] **1.1** Public surface as captured (ingested).\n\n## Notes\n- Ingested from <path> on YYYY-MM-DD."
+}
+```
+
+All implementation tasks are pre-checked (`- [x]`) because the code already exists. New tasks may be added later when refactoring.
+
+### 4. Link the source files
+
+For every file the module covers:
+```
+index_add {
+  topic: "<module>",
+  path: "<path>",
+  link_type: "implementation",
+  tags: "<language>,ingested",
+  annotation: "Source file for module <module>."
+}
+```
+
+For cross-module dependencies, use the CLI to find callers:
+```bash
+unispec index callers <symbol>
+```
+Each caller indicates a topic that depends on yours; capture this via `notes_add` on the dependent topic.
+
+### 5. Recurse
+
+Move to sub-directories. Stop when:
+- A directory has no files of supported languages, or
+- The directory is already represented by a topic (check `topics_list { area: "Ingested" }` first).
+
+---
+
+## Definition of done
+
+For each ingested module:
+- `topics_add` succeeded and `topic.md` shows a real Overview.
+- `spec_add` succeeded and the spec documents every public function/type with file:line references.
+- Every source file in the module is linked via `index_add`.
+- The task file is all `- [x]` (since the code already exists), with a Notes block mentioning the ingest date and source path.
+- Cross-module dependencies are noted on the dependent topic.
+
+For the project overall:
+- `topics_list { area: "Ingested" }` covers every directory of supported source.
+- `unispec index list` returns ≥ one entry for every ingested file.
+
+---
+
+## Failure modes
+
+- **`unispec parse file` returns nothing** — the language isn't supported, or the file has a syntax error. Skip the file and add it to a "skipped" note on the parent topic.
+- **`spec_add` fails on a nested topic** — the parent topic must already exist. Create parents top-down.
+- **`topic.md` already exists when re-ingesting** — `topics_add` errors out. Either delete the existing topic via `topics_delete` (only if you're sure) or update via `spec_write` / `task_write` instead.
+
+---
+
+## Agent rules
+
+- Do not modify any source code during ingest. This workflow only documents existing code.
+- If you can't determine a function's purpose from name + signature + neighbors, write the body description as "TODO: clarify purpose" and add a `notes_add` entry asking the user.
+- Do not invent requirements that the code doesn't actually fulfill. Every `REQ-*` must correspond to a real existing behavior, cited by file:line.

--- a/.agent/workflows/opsx-apply.md
+++ b/.agent/workflows/opsx-apply.md
@@ -1,129 +1,146 @@
 ---
-description: Implement tasks from an OpenSpec change (Experimental)
+description: Implement the tasks from a Staging topic — push to Working, write code, flip checkboxes
 ---
 
-Implement tasks from an OpenSpec change.
+# /opsx:apply
 
-**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+> **Scope note.** This is an OpenSpec-style "apply the change" prompt mapped onto UniSpec's MCP tools. There is **no** `openspec` CLI in this repo — wherever the OpenSpec prompts mention `openspec status`, `openspec instructions`, etc., translate to the UniSpec MCP tools listed below.
 
-**Steps**
+Implement the tasks of a topic created by `/opsx:propose` (or `/spec`). This is the UniSpec BUILD loop with one extra step at the start to select the topic.
 
-1. **Select the change**
+## Input
 
-   If a name is provided, use it. Otherwise:
-   - Infer from conversation context if the user mentioned a change
-   - Auto-select if only one active change exists
-   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+The argument after `/opsx:apply` is the topic name. If omitted:
+- Infer it from conversation context if the user mentioned one.
+- Otherwise, run `topics_list { area: "Staging" }` and ask the user to pick.
 
-   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+Never auto-select among multiple candidates. Always confirm: "Using topic: <name>".
 
-2. **Check status to understand the schema**
-   ```bash
-   openspec status --change "<name>" --json
-   ```
-   Parse the JSON to understand:
-   - `schemaName`: The workflow being used (e.g., "spec-driven")
-   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+## Tools
 
-3. **Get apply instructions**
+MCP:
+- `topics_list { area }`
+- `queue_check { topic, area }`
+- `queue_add { topic, area }`
+- `topics_push { topic, area, source_area? }`
+- `unispec_read_spec { topic, area }`
+- `tasks_list { topic, area }`
+- `task_status { topic, area, status }`
+- `tasks_complete { topic, task_index, note? }`
+- `index_add { topic, path, link_type, tags?, annotation? }`
+- `notes_add { topic, note }`
+- `read_asset { topic, asset_type, area }`
+- `task_write { topic, area, content }`
 
-   ```bash
-   openspec instructions apply --change "<name>" --json
-   ```
+## Steps
 
-   This returns:
-   - Context file paths (varies by schema)
-   - Progress (total, complete, remaining)
-   - Task list with status
-   - Dynamic instruction based on current state
+### 1. Select the topic
+- If a name was provided, use it.
+- Otherwise list candidates from Staging:
+  ```
+  topics_list { area: "Staging" }
+  ```
+  Then ask the user which to apply. Don't auto-select.
 
-   **Handle states:**
-   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
-   - If `state: "all_done"`: congratulate, suggest archive
-   - Otherwise: proceed to implementation
+Announce: "Using topic: <name>".
 
-4. **Read context files**
-
-   Read the files listed in `contextFiles` from the apply instructions output.
-   The files depend on the schema being used:
-   - **spec-driven**: proposal, specs, design, tasks
-   - Other schemas: follow the contextFiles from CLI output
-
-5. **Show current progress**
-
-   Display:
-   - Schema being used
-   - Progress: "N/M tasks complete"
-   - Remaining tasks overview
-   - Dynamic instruction from CLI
-
-6. **Implement tasks (loop until done or blocked)**
-
-   For each pending task:
-   - Show which task is being worked on
-   - Make the code changes required
-   - Keep changes minimal and focused
-   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
-   - Continue to next task
-
-   **Pause if:**
-   - Task is unclear → ask for clarification
-   - Implementation reveals a design issue → suggest updating artifacts
-   - Error or blocker encountered → report and wait for guidance
-   - User interrupts
-
-7. **On completion or pause, show status**
-
-   Display:
-   - Tasks completed this session
-   - Overall progress: "N/M tasks complete"
-   - If all done: suggest archive
-   - If paused: explain why and wait for guidance
-
-**Output During Implementation**
-
+### 2. Verify readiness and push to Working
 ```
-## Implementing: <change-name> (schema: <schema-name>)
-
-Working on task 3/7: <task description>
-[...implementation happening...]
-✓ Task complete
-
-Working on task 4/7: <task description>
-[...implementation happening...]
-✓ Task complete
+queue_check { topic: "<name>", area: "Staging" }
+```
+If `ready: false`:
+```
+queue_add   { topic: "<name>", area: "Staging" }
+queue_check { topic: "<name>", area: "Staging" }   # must now be ready: true
+```
+Then push:
+```
+topics_push { topic: "<name>", area: "Working" }
 ```
 
-**Output On Completion**
+### 3. Load the spec
+```
+unispec_read_spec { topic: "<name>", area: "Working" }
+tasks_list        { topic: "<name>", area: "Working" }
+task_status       { topic: "<name>", area: "Working", status: "working" }
+```
+
+Show progress so the user can track:
+```
+## Implementing <name>
+Progress: 0/<M> tasks complete
+Remaining tasks:
+- task 0: <text>
+- task 1: <text>
+...
+```
+
+### 4. Implement each task in order
+
+For each open task at index `N`:
+
+1. Announce: `"Working on task N: <text>"`.
+2. Make minimal, focused changes in `src/`.
+3. `index_add { topic: "<name>", path: "src/<file>", link_type: "implementation", … }`.
+4. `tasks_complete { topic: "<name>", task_index: N }`.
+5. If you made a decision the spec didn't pin, `notes_add { topic: "<name>", note: "<decision + reason>" }`.
+
+After each task, show updated progress.
+
+**Pause if:**
+- A task is unclear → ask the user.
+- The spec is wrong/incomplete → propose updating it via `spec_write` (or `notes_add`).
+- A real error blocks the work → report and wait.
+- The user interrupts.
+
+### 5. Append test tasks
+```
+read_asset { topic: "<name>", asset_type: "task", area: "Working" }
+task_write {
+  topic: "<name>",
+  area: "Working",
+  content: "<original body + ### Phase 5: Testing block of `- [ ]` items>"
+}
+```
+
+### 6. Promote
+```
+task_status { topic: "<name>", area: "Working", status: "complete" }
+topics_push { topic: "<name>", area: "Testing" }
+```
+
+## Output during implementation
+
+```
+## Implementing: <name>
+Working on task 3/7: <task text>
+[…changes…]
+✓ Task complete (task_index 2)
+```
+
+## Output on completion
 
 ```
 ## Implementation Complete
 
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 7/7 tasks complete ✓
+Topic: <name>
+Tasks: 7/7 (100%)
 
-### Completed This Session
-- [x] Task 1
-- [x] Task 2
-...
-
-All tasks complete! You can archive this change with `/opsx:archive`.
+Next: /opsx:verify <name>   (or /test, /verify)
 ```
 
-**Output On Pause (Issue Encountered)**
+## Output on pause
 
 ```
 ## Implementation Paused
 
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 4/7 tasks complete
+Topic: <name>
+Progress: 4/7 tasks complete
 
-### Issue Encountered
-<description of the issue>
+### Issue
+<short description of what blocked progress>
 
-**Options:**
+### Options
 1. <option 1>
 2. <option 2>
 3. Other approach
@@ -131,19 +148,18 @@ All tasks complete! You can archive this change with `/opsx:archive`.
 What would you like to do?
 ```
 
-**Guardrails**
-- Keep going through tasks until done or blocked
-- Always read context files before starting (from the apply instructions output)
-- If task is ambiguous, pause and ask before implementing
-- If implementation reveals issues, pause and suggest artifact updates
-- Keep code changes minimal and scoped to each task
-- Update task checkbox immediately after completing each task
-- Pause on errors, blockers, or unclear requirements - don't guess
-- Use contextFiles from CLI output, don't assume specific file names
+## Definition of done
 
-**Fluid Workflow Integration**
+- Every original implementation task in `<name>_task.md` is `- [x]`.
+- `task_status` is `complete`.
+- Every file written in `src/` has an `index_add` link.
+- A `### Phase 5: Testing` block has been appended via `task_write`.
+- The topic is in `Testing`.
 
-This skill supports the "actions on a change" model:
+## Guardrails
 
-- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
-- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly
+- Keep changes minimal per task — don't rewrite unrelated code.
+- Always read the spec before starting.
+- Flip checkboxes immediately, not at the end.
+- Pause on real ambiguity; don't guess at requirements.
+- Don't write production code while paused; use `notes_add` to capture investigation results instead.

--- a/.agent/workflows/opsx-archive.md
+++ b/.agent/workflows/opsx-archive.md
@@ -1,154 +1,107 @@
 ---
-description: Archive a completed change in the experimental workflow
+description: Archive a completed topic — move it to the Build area
 ---
 
-Archive a completed change in the experimental workflow.
+# /opsx:archive
 
-**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+> **Scope note.** This is an OpenSpec-style "archive a completed change" prompt mapped onto UniSpec. There is **no** `openspec` CLI — wherever OpenSpec workflows say "archive", in UniSpec this means moving the topic to the `Build` area, which is treated as immutable.
 
-**Steps**
+Archive a completed topic by promoting it to `Build`. UniSpec does not delete or rename topics on archive; instead, `Build` is the immutable final stage of the pipeline.
 
-1. **If no change name provided, prompt for selection**
+## Input
 
-   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+The argument after `/opsx:archive` is the topic name. If omitted, list candidates from `Testing` (since archive should only follow successful tests) and ask the user to pick:
+```
+topics_list { area: "Testing" }
+```
+Never auto-select among multiple candidates.
 
-   Show only active changes (not already archived).
-   Include the schema used for each change if available.
+## Tools
 
-   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+MCP:
+- `topics_list { area }`
+- `topics_show { topic, area }`
+- `unispec_read_spec { topic, area }`
+- `tasks_list { topic, area }`
+- `notes_add { topic, note }`
+- `task_status { topic, area, status }`
+- `topics_push { topic, area }`
 
-2. **Check artifact completion status**
+## Steps
 
-   Run `openspec status --change "<name>" --json` to check artifact completion.
+### 1. Confirm the topic
+Ask the user (or accept the argument). Announce: "Archiving topic: <name>".
 
-   Parse the JSON to understand:
-   - `schemaName`: The workflow being used
-   - `artifacts`: List of artifacts with their status (`done` or other)
+### 2. Check completeness
 
-   **If any artifacts are not `done`:**
-   - Display warning listing incomplete artifacts
-   - Prompt user for confirmation to continue
-   - Proceed if user confirms
-
-3. **Check task completion status**
-
-   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
-
-   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
-
-   **If incomplete tasks found:**
-   - Display warning showing count of incomplete tasks
-   - Prompt user for confirmation to continue
-   - Proceed if user confirms
-
-   **If no tasks file exists:** Proceed without task-related warning.
-
-4. **Assess delta spec sync state**
-
-   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
-
-   **If delta specs exist:**
-   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
-   - Determine what changes would be applied (adds, modifications, removals, renames)
-   - Show a combined summary before prompting
-
-   **Prompt options:**
-   - If changes needed: "Sync now (recommended)", "Archive without syncing"
-   - If already synced: "Archive now", "Sync anyway", "Cancel"
-
-   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
-
-5. **Perform the archive**
-
-   Create the archive directory if it doesn't exist:
-   ```bash
-   mkdir -p openspec/changes/archive
+a. **Spec + tasks present:**
    ```
-
-   Generate target name using current date: `YYYY-MM-DD-<change-name>`
-
-   **Check if target already exists:**
-   - If yes: Fail with error, suggest renaming existing archive or using different date
-   - If no: Move the change directory to archive
-
-   ```bash
-   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   topics_show { topic: "<name>", area: "Testing" }
    ```
+   Must list `topic.md`, `<name>_spec.md`, `<name>_task.md`.
 
-6. **Display summary**
+b. **All tasks complete:**
+   ```
+   tasks_list { topic: "<name>", area: "Testing" }
+   ```
+   Count `- [ ]` (incomplete) vs `- [x]` (complete). **If any are incomplete**, show the count and prompt:
+   ```
+   <N> incomplete tasks remain. Archive anyway?
+   ```
+   Proceed only on explicit user confirmation.
 
-   Show archive completion summary including:
-   - Change name
-   - Schema that was used
-   - Archive location
-   - Spec sync status (synced / sync skipped / no delta specs)
-   - Note about any warnings (incomplete artifacts/tasks)
+c. **Test run captured:** Inspect the notes block of `<name>_task.md` for a recent `Test run` or `Verification` entry. If missing, warn and prompt for confirmation.
 
-**Output On Success**
-
+### 3. Promote to Build
 ```
-## Archive Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
-**Specs:** ✓ Synced to main specs
-
-All artifacts complete. All tasks complete.
+task_status { topic: "<name>", area: "Testing", status: "complete" }
+topics_push { topic: "<name>", area: "Build" }
 ```
+`Build` is configured as a protected area in `.agent/modes/default/mode.toml`. After this push, you should not modify the topic in `Build`. To make further changes, run `topics_pull { topic, source_area: "Build" }` to bring it back into `Working`.
 
-**Output On Success (No Delta Specs)**
-
+### 4. Record the archive
 ```
-## Archive Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
-**Specs:** No delta specs
-
-All artifacts complete. All tasks complete.
+notes_add {
+  topic: "<name>",
+  note: "Archived to Build on YYYY-MM-DD.\n  Test run: <link or summary>\n  Verification: <link or summary>"
+}
 ```
 
-**Output On Success With Warnings**
+### 5. Summarize
 
 ```
-## Archive Complete (with warnings)
+## Archived: <name>
 
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
-**Specs:** Sync skipped (user chose to skip)
+Pipeline: Staging → Working → Testing → Build
+Final files:
+- spec/Build/<name>/topic.md
+- spec/Build/<name>/<name>_spec.md
+- spec/Build/<name>/<name>_task.md
 
-**Warnings:**
-- Archived with 2 incomplete artifacts
-- Archived with 3 incomplete tasks
-- Delta spec sync was skipped (user chose to skip)
-
-Review the archive if this was not intentional.
+Build is treated as immutable. To resume work, run topics_pull { topic: "<name>", source_area: "Build" }.
 ```
 
-**Output On Error (Archive Exists)**
+## Definition of done
+
+- The topic exists under `spec/Build/<name>/` with all three files.
+- `task_status` is `complete`.
+- A `notes_add` entry records the archive date and references the verification result.
+- If incomplete tasks or missing verification were waived, the user explicitly confirmed.
+
+## Output on warnings
 
 ```
-## Archive Failed
+## Archived (with warnings): <name>
 
-**Change:** <change-name>
-**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+Warnings:
+- <N> incomplete tasks at archive time (user confirmed).
+- Verification block not found in notes (user confirmed).
 
-Target archive directory already exists.
-
-**Options:**
-1. Rename the existing archive
-2. Delete the existing archive if it's a duplicate
-3. Wait until a different date to archive
+Review spec/Build/<name>/<name>_task.md if this wasn't intentional.
 ```
 
-**Guardrails**
-- Always prompt for change selection if not provided
-- Use artifact graph (openspec status --json) for completion checking
-- Don't block archive on warnings - just inform and confirm
-- Preserve .openspec.yaml when moving to archive (it moves with the directory)
-- Show clear summary of what happened
-- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
-- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+## Guardrails
+
+- Don't auto-archive. Always confirm with the user, especially with warnings.
+- Don't bypass the `topics_push` flow with raw filesystem moves — that breaks the index.
+- Once in `Build`, treat the topic as read-only. Pull it back into `Working` if changes are needed.

--- a/.agent/workflows/opsx-explore.md
+++ b/.agent/workflows/opsx-explore.md
@@ -1,170 +1,110 @@
 ---
-description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+description: Explore-mode partner — think through ideas, investigate the repo, do NOT implement
 ---
 
-Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+# /opsx:explore
 
-**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+> **Scope note.** This workflow is an OpenSpec-style "explore mode" prompt that lives alongside UniSpec's own workflows. It does **not** require or call the external `openspec` CLI. Where this prompt mentions "changes", "proposals", or `openspec/`, treat those as ideas — there is no `openspec` binary in this repository. To capture decisions, use UniSpec's MCP tools: `topics_add`, `spec_add`, `notes_add`, `spec_write`.
 
-**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+Enter explore mode. Think before doing. You may read files, search code, ask clarifying questions, and sketch designs. You may **not** write production code in this mode.
 
-**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
-- A vague idea: "real-time collaboration"
-- A specific problem: "the auth system is getting unwieldy"
-- A change name: "add-dark-mode" (to explore in context of that change)
-- A comparison: "postgres vs sqlite for this"
-- Nothing (just enter explore mode)
+You **may** create UniSpec artifacts (topic, spec, task) if the user asks — that captures thinking, not implementation.
 
----
+## The stance
 
-## The Stance
+- **Curious, not prescriptive** — ask questions that emerge naturally.
+- **Open threads, not interrogations** — surface multiple directions; let the user pick.
+- **Visual** — ASCII diagrams beat paragraphs when they fit.
+- **Adaptive** — follow promising threads; pivot when new evidence appears.
+- **Grounded** — read the actual repo. Don't theorize about code you haven't seen.
 
-- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
-- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
-- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
-- **Adaptive** - Follow interesting threads, pivot when new information emerges
-- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
-- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+## Input
 
----
+The argument after `/opsx:explore` is what the user wants to think about. Could be:
+- A vague idea: "real-time collaboration".
+- A specific problem: "the auth system is getting unwieldy".
+- A topic name: "auth/login" — explore in the context of that topic.
+- A comparison: "postgres vs sqlite for this".
+- Nothing — just enter explore mode.
 
-## What You Might Do
+## What you might do
 
-Depending on what the user brings, you might:
+- **Explore the problem.** Ask clarifying questions. Challenge assumptions. Find analogies.
+- **Investigate the repo.** Use `topics_list`, `topics_show`, `unispec_read_spec`, `index_find` to map existing structure. Read source files. Identify integration points.
+- **Compare options.** Brainstorm approaches; build comparison tables; recommend a path when asked.
+- **Visualize.** ASCII diagrams of state machines, data flow, architecture, dependency graphs.
+- **Surface risks.** What could go wrong? What's unknown?
 
-**Explore the problem space**
-- Ask clarifying questions that emerge from what they said
-- Challenge assumptions
-- Reframe the problem
-- Find analogies
+## UniSpec context
 
-**Investigate the codebase**
-- Map existing architecture relevant to the discussion
-- Find integration points
-- Identify patterns already in use
-- Surface hidden complexity
+Before exploring deeply, orient on what already exists:
 
-**Compare options**
-- Brainstorm multiple approaches
-- Build comparison tables
-- Sketch tradeoffs
-- Recommend a path (if asked)
-
-**Visualize**
 ```
-┌─────────────────────────────────────────┐
-│     Use ASCII diagrams liberally        │
-├─────────────────────────────────────────┤
-│                                         │
-│   ┌────────┐         ┌────────┐        │
-│   │ State  │────────▶│ State  │        │
-│   │   A    │         │   B    │        │
-│   └────────┘         └────────┘        │
-│                                         │
-│   System diagrams, state machines,      │
-│   data flows, architecture sketches,    │
-│   dependency graphs, comparison tables  │
-│                                         │
-└─────────────────────────────────────────┘
+areas_list
+topics_list { area: "Staging" }
+topics_list { area: "Working" }
+queue_list  { area: "Working" }
 ```
 
-**Surface risks and unknowns**
-- Identify what could go wrong
-- Find gaps in understanding
-- Suggest spikes or investigations
-
----
-
-## OpenSpec Awareness
-
-You have full context of the OpenSpec system. Use it naturally, don't force it.
-
-### Check for context
-
-At the start, quickly check what exists:
-```bash
-openspec list --json
+If the user mentioned a topic name, load it:
+```
+unispec_read_spec { topic: "<name>", area: "<area>" }
+index_list        { topic: "<name>" }
 ```
 
-This tells you:
-- If there are active changes
-- Their names, schemas, and status
-- What the user might be working on
+## When a topic doesn't exist yet
 
-If the user mentioned a specific change name, read its artifacts for context.
+Think freely. When the idea is concrete enough, offer to capture:
+- "This feels ready to spec. Want me to run /spec for it?"
+- "Should I record this as a note on an existing topic?"
 
-### When no change exists
+Don't pressure. Don't auto-capture. The user decides.
 
-Think freely. When insights crystallize, you might offer:
+## When a topic exists
 
-- "This feels solid enough to start a change. Want me to create a proposal?"
-- Or keep exploring - no pressure to formalize
+Read its artifacts. Reference them naturally:
+- "Your spec mentions REQ-003 — the in-depth section doesn't cover the timeout case…"
+- "The Notes block says you chose argon2id; that affects how this new flow signs tokens."
 
-### When a change exists
+| Insight | Capture via |
+|---------|-------------|
+| New requirement discovered | `spec_write` (rewrite the spec with the new REQ) |
+| Design decision made | `notes_add` |
+| Scope expanded/shrunk | `spec_write` |
+| New task discovered | `task_write` (preserve existing content) |
+| Assumption invalidated | `notes_add` |
 
-If the user mentions a change or you detect one is relevant:
+## What you don't have to do
 
-1. **Read existing artifacts for context**
-   - `openspec/changes/<name>/proposal.md`
-   - `openspec/changes/<name>/design.md`
-   - `openspec/changes/<name>/tasks.md`
-   - etc.
+- Follow a script.
+- Ask the same questions every time.
+- Produce a specific artifact.
+- Reach a conclusion in this session.
+- Stay on topic if a tangent is genuinely valuable.
 
-2. **Reference them naturally in conversation**
-   - "Your design mentions using Redis, but we just realized SQLite fits better..."
-   - "The proposal scopes this to premium users, but we're now thinking everyone..."
-
-3. **Offer to capture when decisions are made**
-
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
-   | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
-
-   Example offers:
-   - "That's a design decision. Capture it in design.md?"
-   - "This is a new requirement. Add it to specs?"
-   - "This changes scope. Update the proposal?"
-
-4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
-
----
-
-## What You Don't Have To Do
-
-- Follow a script
-- Ask the same questions every time
-- Produce a specific artifact
-- Reach a conclusion
-- Stay on topic if a tangent is valuable
-- Be brief (this is thinking time)
-
----
-
-## Ending Discovery
+## Ending the session
 
 There's no required ending. Discovery might:
+- Flow into a `/spec` invocation.
+- Result in `notes_add` or `spec_write` updates.
+- Just provide clarity — user moves on.
+- Pause and continue later.
 
-- **Flow into a proposal**: "Ready to start? I can create a change proposal."
-- **Result in artifact updates**: "Updated design.md with these decisions"
-- **Just provide clarity**: User has what they need, moves on
-- **Continue later**: "We can pick this up anytime"
-
-When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
-
----
+When things crystallize, offer a short summary. The user decides whether to commit it.
 
 ## Guardrails
 
-- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
-- **Don't fake understanding** - If something is unclear, dig deeper
-- **Don't rush** - Discovery is thinking time, not task time
-- **Don't force structure** - Let patterns emerge naturally
-- **Don't auto-capture** - Offer to save insights, don't just do it
-- **Do visualize** - A good diagram is worth many paragraphs
-- **Do explore the codebase** - Ground discussions in reality
-- **Do question assumptions** - Including the user's and your own
+- **Don't implement.** No production code in explore mode. Creating UniSpec artifacts is fine; editing `src/` is not.
+- **Don't fake understanding.** If something's unclear, dig deeper.
+- **Don't auto-capture.** Offer; let the user say yes.
+- **Do question assumptions** — the user's and your own.
+- **Do explore the real code** with `read_asset`, `index_find`, and the host editor's Read tool.
+
+## Definition of done
+
+Explore mode is "done" when one of these is true:
+- The user has enough clarity to invoke another workflow (`/spec`, `/build`, `/verify`).
+- A specific artifact was created/updated with the user's approval (`notes_add`, `spec_write`, etc.).
+- The user explicitly ends the session.
+
+If none of those happen, the session simply pauses — that's fine.

--- a/.agent/workflows/opsx-propose.md
+++ b/.agent/workflows/opsx-propose.md
@@ -1,103 +1,115 @@
 ---
-description: Propose a new change - create it and generate all artifacts in one step
+description: Propose a new change — create a topic with spec and tasks in one step
 ---
 
-Propose a new change - create the change and generate all artifacts in one step.
+# /opsx:propose
 
-I'll create a change with artifacts:
-- proposal.md (what & why)
-- design.md (how)
-- tasks.md (implementation steps)
+> **Scope note.** This is an OpenSpec-style "propose a change" prompt mapped onto UniSpec's MCP tools. There is **no** `openspec` CLI in this repository — anywhere this prompt mentions `openspec status`, `openspec instructions`, or `.openspec.yaml`, use the corresponding UniSpec MCP tools listed below instead.
 
-When ready to implement, run /opsx:apply
+In one step, create a topic and a spec + task list in `Staging`. When ready to implement, run `/opsx:apply` (or `/build`).
 
----
+## Input
 
-**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+The argument after `/opsx:propose` is either:
+- A kebab-case topic name, e.g. `add-user-auth`.
+- A description of the change ("add user authentication"). Derive a kebab-case name from it (`add-user-auth`).
 
-**Steps**
+If no argument is provided, ask the user:
+> "What change do you want to work on? Describe what you want to build or fix."
 
-1. **If no input provided, ask what they want to build**
+Do not proceed without a clear answer. A vague answer earns one follow-up question.
 
-   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
-   > "What change do you want to work on? Describe what you want to build or fix."
+## Tools
 
-   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+| Tool | Required args | Purpose |
+|------|---------------|---------|
+| `topics_list` | — | Confirm the chosen name isn't taken. |
+| `read_asset` | `topic: "templates", asset_type: …` | Read templates for the topic/spec/task body. |
+| `topics_add` | `topic, area, short, content` | Create `spec/Staging/<name>/topic.md`. |
+| `spec_add` | `topic, area, short, spec_content, task_content` | Create `<name>_spec.md` + `<name>_task.md`. |
+| `queue_add` | `topic, area` | Add to `spec/Staging/queue.md`. |
 
-   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+## Steps
 
-2. **Create the change directory**
-   ```bash
-   openspec new change "<name>"
-   ```
-   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+### 1. Verify the name is free
+```
+topics_list { area: "Staging" }
+```
+If `<name>` already exists, ask whether to update it (`/spec`) or pick a different name.
 
-3. **Get the artifact build order**
-   ```bash
-   openspec status --change "<name>" --json
-   ```
-   Parse the JSON to get:
-   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
-   - `artifacts`: list of all artifacts with their status and dependencies
+### 2. Read the templates
+```
+read_asset { topic: "templates", asset_type: "topic" }
+read_asset { topic: "templates", asset_type: "spec" }
+read_asset { topic: "templates", asset_type: "task" }
+```
 
-4. **Create artifacts in sequence until apply-ready**
+### 3. Create the topic
+```
+topics_add {
+  topic: "<name>",
+  area: "Staging",
+  short: "<one-line description>",
+  content: "<topic body mirroring templates/topic.md, real content>"
+}
+```
+`content` must be ≥ 10 chars. Don't include `---`; the server writes frontmatter.
 
-   Use the **TodoWrite tool** to track progress through the artifacts.
+### 4. Create the spec + tasks
+```
+spec_add {
+  topic: "<name>",
+  area: "Staging",
+  short: "<one-line description>",
+  spec_content: "<body mirroring templates/spec.md, every section filled>",
+  task_content: "<body mirroring templates/task.md, implementation tasks only>"
+}
+```
 
-   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+Both `spec_content` and `task_content` must be ≥ 10 chars. Server strips your `---` and writes its own.
 
-   a. **For each artifact that is `ready` (dependencies satisfied)**:
-      - Get instructions:
-        ```bash
-        openspec instructions <artifact-id> --change "<name>" --json
-        ```
-      - The instructions JSON includes:
-        - `context`: Project background (constraints for you - do NOT include in output)
-        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
-        - `template`: The structure to use for your output file
-        - `instruction`: Schema-specific guidance for this artifact type
-        - `outputPath`: Where to write the artifact
-        - `dependencies`: Completed artifacts to read for context
-      - Read any completed dependency files for context
-      - Create the artifact file using `template` as the structure
-      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
-      - Show brief progress: "Created <artifact-id>"
+### 5. Register in the queue
+```
+queue_add { topic: "<name>", area: "Staging" }
+```
 
-   b. **Continue until all `applyRequires` artifacts are complete**
-      - After creating each artifact, re-run `openspec status --change "<name>" --json`
-      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
-      - Stop when all `applyRequires` artifacts are done
+### 6. Verify
+```
+topics_show { topic: "<name>", area: "Staging" }
+queue_check { topic: "<name>", area: "Staging" }
+```
 
-   c. **If an artifact requires user input** (unclear context):
-      - Use **AskUserQuestion tool** to clarify
-      - Then continue with creation
+## Content rules
 
-5. **Show final status**
-   ```bash
-   openspec status --change "<name>"
-   ```
+- **Spec = WHAT, not HOW.** Use SHALL/SHOULD; acceptance criteria are checkable.
+- **Tasks = implementation only.** No test tasks here.
+- **No placeholders.** `[Requirement statement]` etc. exist in templates to be replaced.
+- **Nested topics use `/`.** Parent must already exist.
 
-**Output**
+## Definition of done
 
-After completing all artifacts, summarize:
-- Change name and location
-- List of artifacts created with brief descriptions
-- What's ready: "All artifacts created! Ready for implementation."
-- Prompt: "Run `/opsx:apply` to start implementing."
+- `topic.md`, `<name>_spec.md`, `<name>_task.md` all exist in `spec/Staging/<name>/`.
+- The spec contains at least one `REQ-*` row and at least one example.
+- The task file has only implementation tasks.
+- `queue_check` returns `ready: true`.
 
-**Artifact Creation Guidelines**
+## Output
 
-- Follow the `instruction` field from `openspec instructions` for each artifact type
-- The schema defines what each artifact should contain - follow it
-- Read dependency artifacts for context before creating new ones
-- Use `template` as the structure for your output file - fill in its sections
-- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
-  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
-  - These guide what you write, but should never appear in the output
+```
+## Proposal Created: <name>
 
-**Guardrails**
-- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
-- Always read dependency artifacts before creating a new one
-- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
-- If a change with that name already exists, ask if user wants to continue it or create a new one
-- Verify each artifact file exists after writing before proceeding to next
+Files:
+- spec/Staging/<name>/topic.md
+- spec/Staging/<name>/<name>_spec.md
+- spec/Staging/<name>/<name>_task.md
+
+Queue: Staging/queue.md updated.
+Next: /opsx:apply <name>  (or /build <name>)
+```
+
+## Guardrails
+
+- Create ALL three files (topic, spec, task) in this single workflow — never partial.
+- If `topics_add` or `spec_add` fails, stop and report the exact error; don't try to repair file state manually with Write tools.
+- If a topic with this name already exists, ask the user whether to continue with `/spec` (update) or pick a new name.
+- Don't fabricate requirements. If you don't know enough, ask the user.

--- a/.agent/workflows/osdd:build.md
+++ b/.agent/workflows/osdd:build.md
@@ -1,10 +1,10 @@
 ---
-description: Build implementation from Staging spec, pushes to Working
+description: Implement a Staging spec — push to Working, write code in src/, link files, flip task checkboxes, push to Testing
 ---
 
 # /osdd:build
 
-Build implementation from a Staging spec. Pushes to Working and implements.
+Build a topic from Staging using UniSpec's MCP tools. The `osdd:` prefix is historical; the binary is `unispec` and the file operations are MCP calls.
 
 ## Usage
 ```
@@ -12,74 +12,112 @@ Build implementation from a Staging spec. Pushes to Working and implements.
 ```
 
 ## Rules
-1. **Read spec first** - Never guess requirements
-2. **Follow tasks in order** - Complete each before moving on
-3. **Document decisions** - Add notes for anything not in spec
-4. **Mark tasks complete** - Update tasks.md immediately
-5. **Stay faithful** - If spec says X, implement X
+
+1. **Read the spec first.** Never guess requirements; always call `unispec_read_spec` before writing code.
+2. **One task at a time, in order.** Don't skip ahead.
+3. **Flip the checkbox immediately.** Call `tasks_complete` after each finished task — do not batch.
+4. **Document decisions.** Use `notes_add` whenever you choose something that isn't pinned by the spec.
+5. **Stay faithful to the spec.** If the spec says X, implement X. If you must diverge, surface it to the user before merging.
+
+## Preconditions
+
+- `<TopicName>` exists in Staging with `<TopicName>_spec.md` and `<TopicName>_task.md`.
+- `<TopicName>` appears in `spec/Staging/queue.md` (`queue_check` returns `ready: true`).
+- `src/` exists at the project root.
+
+If any precondition fails, run `/osdd:spec <TopicName>` and `queue_add` first.
 
 ## Steps
 
-### 1. Locate Spec
-- Verify `spec/Staging/<TopicName>/specs.md` exists
-- Read it thoroughly
-
-### 2. Push to Working
-```bash
-osdd push <TopicName> Working
+### 1. Verify readiness and push to Working
 ```
-This creates `spec/Working/<TopicName>/` with specs.md copied.
-
-### 3. Create tasks.md (if missing)
-```markdown
-# Tasks for <TopicName>
-
-## Phase 1: Foundation
-- [ ] **1.1** [Task based on REQ-1]
-
-## Phase 2: Core
-- [ ] **2.1** [Task based on REQ-2]
-
-## Phase 3: Testing
-- [ ] **3.1** [Verify implementation]
-
-## Notes
-- **YYYY-MM-DD**: Initial tasks created
+queue_check  { topic: "<TopicName>", area: "Staging" }
+topics_push  { topic: "<TopicName>", area: "Working" }
 ```
 
-### 4. Implement Each Task
-For each pending task:
-
-1. **Announce**: "Working on Task X.X: [description]"
-2. **Read spec** for relevant requirements
-3. **Implement** code
-4. **Add notes** if you make decisions not in spec
-5. **Mark complete**: `- [ ]` → `- [x]`
-
-### 5. Track Progress
-Show progress after each task:
+### 2. Load the spec
 ```
-Progress: 2/5 tasks (40%)
+unispec_read_spec { topic: "<TopicName>", area: "Working" }
+tasks_list        { topic: "<TopicName>", area: "Working" }
+task_status       { topic: "<TopicName>", area: "Working", status: "working" }
 ```
 
-## Notes Format
-```markdown
-## Notes
-- **YYYY-MM-DD**: [Decision made]
-  - Reason: [Why]
-  - Alternative: [What else was considered]
+### 3. For each open task at index `N`
+1. Announce: "Working on task N: <text from tasks_list>".
+2. Write code into `src/`.
+3. Link it:
+   ```
+   index_add {
+     topic: "<TopicName>",
+     path: "src/<file>",
+     link_type: "implementation",
+     tags: "<…>",
+     annotation: "<one-line role of this file>"
+   }
+   ```
+4. Flip the checkbox:
+   ```
+   tasks_complete { topic: "<TopicName>", task_index: N }
+   ```
+5. If you made a decision the spec didn't pin:
+   ```
+   notes_add { topic: "<TopicName>", note: "Date YYYY-MM-DD: <decision>\n  Reason: <why>\n  Alternative: <what was rejected>" }
+   ```
+
+After each task, report progress:
+```
+Progress: X/Y tasks (Z%)
 ```
 
-## On Completion
+### 4. Append test tasks
+Read the current task body, then overwrite with the original content + a new `### Phase 5: Testing` block of `- [ ]` items:
+```
+read_asset { topic: "<TopicName>", asset_type: "task", area: "Working" }
+task_write {
+  topic: "<TopicName>",
+  area: "Working",
+  content: "<original body + Phase 5: Testing block>"
+}
+```
+
+### 5. Promote to Testing
+```
+task_status { topic: "<TopicName>", area: "Working", status: "complete" }
+topics_push { topic: "<TopicName>", area: "Testing" }
+```
+
+## Files produced/touched
+
+```
+src/                        # code written here
+spec/Working/<TopicName>/
+├── topic.md
+├── <TopicName>_spec.md     # unchanged unless you also call spec_write
+└── <TopicName>_task.md     # checkboxes flipped, status updated, notes appended
+```
+
+## Definition of done
+
+- Every implementation task is `- [x]` in `<TopicName>_task.md`.
+- `task_status` is `complete`.
+- Every file written to `src/` has a corresponding `index_add` link.
+- Decisions not in the spec are captured in the task file's notes section.
+- A `### Phase 5: Testing` block has been appended via `task_write`.
+- `topics_push { area: "Testing" }` succeeded.
+
+## Output on completion
+
 ```
 ## Build Complete: <TopicName>
 
-Tasks: 5/5 (100%)
-Ready for /osdd:verify <TopicName>
+Tasks: N/N (100%)
+Topic now in Testing.
+Next: /osdd:verify <TopicName>
 ```
 
 ## Guardrails
-- Don't skip tasks
-- Don't leave TODOs in code
-- If spec is unclear, ask instead of guessing
-- If implementation differs from spec, document it
+
+- Don't skip tasks. If a task is impossible to do, stop and ask the user.
+- Don't leave `TODO:` markers in code; they don't show up in `tasks_list`.
+- If the spec is genuinely unclear, ask the user — don't fabricate an answer.
+- If your implementation diverges from the spec, capture it via `notes_add` and tell the user.

--- a/.agent/workflows/osdd:spec.md
+++ b/.agent/workflows/osdd:spec.md
@@ -1,10 +1,12 @@
 ---
-description: Create a specification in Staging area
+description: Create a spec in Staging via the UniSpec MCP server
 ---
 
 # /osdd:spec
 
-Create a new specification in the **Staging area only**.
+Create a new specification in the **Staging** area using UniSpec's MCP tools.
+
+The `osdd:` prefix is historical (the project's predecessor was OpenSDD). The actual binary is `unispec`, and the file-management tool calls are MCP tools — `osdd` is not a CLI you can shell out to.
 
 ## Usage
 ```
@@ -12,49 +14,74 @@ Create a new specification in the **Staging area only**.
 ```
 
 ## Rules
-1. **Staging only** - Never create specs in Working or Build
-2. **WHAT not HOW** - Specify requirements, not implementation
-3. **Unique names** - Topic names must not duplicate existing ones
-4. **No `/` in names** - Use nested directory structure if needed
+
+1. **Staging only.** Never create specs directly in Working or Build.
+2. **WHAT, not HOW.** Spec out requirements; implementation choices belong in the BUILD phase.
+3. **Unique names.** Run `topics_list { area: "Staging" }` first to confirm `<TopicName>` is not already taken.
+4. **Nested topics use `/`** (e.g., `auth/login`). The parent topic must already exist via `topics_add`.
 
 ## Steps
 
-### 1. Validate
-- Check topic doesn't exist in `spec/Staging/`
-- Parse topic name (PascalCase recommended)
+### 1. Verify the topic name is free
+```
+topics_list { area: "Staging" }
+```
+If `<TopicName>` already appears, either pick a new name or use `/spec` to update the existing one.
 
-### 2. Create Directory
+### 2. Create the topic
+```
+topics_add {
+  topic: "<TopicName>",
+  area: "Staging",
+  short: "<one-line description>",
+  content: "# <TopicName>\n\n## Overview\n<2-3 sentences>\n\n## Specs\n- <TopicName>_spec.md: <what it covers>\n\n## Sub-topics\n- (none yet)\n\n## Notes\n- Created <YYYY-MM-DD>."
+}
+```
+
+### 3. Create the spec + task files
+```
+spec_add {
+  topic: "<TopicName>",
+  area: "Staging",
+  short: "<one-line description>",
+  spec_content: "# Design: <TopicName>\n\n## Overview\n<what does this feature do, and why is it needed>\n\n## Purpose\n<problem solved, who benefits>\n\n## In-Depth Details\n<technical explanation>\n\n## Requirements\n| ID | Requirement | Priority |\n|----|-------------|----------|\n| REQ-001 | The service SHALL <…>. | Must |\n\n## Examples\n### Example 1: <name>\n- Input: <…>\n- Output: <…>\n\n## Data Model\n<entities + fields>\n\n## Out of Scope\n- <what this spec does NOT cover>",
+  task_content: "# Tasks: <TopicName>\n\n## Implementation\n\n### Phase 1: Foundation\n- [ ] **1.1** <concrete task>\n\n### Phase 2: Core Features\n- [ ] **2.1** <concrete task>\n\n## Notes\n"
+}
+```
+
+### 4. Register in the readiness queue
+```
+queue_add { topic: "<TopicName>", area: "Staging" }
+```
+
+### 5. Verify
+```
+topics_show { topic: "<TopicName>", area: "Staging" }
+queue_check { topic: "<TopicName>", area: "Staging" }
+```
+
+## Files produced
+
 ```
 spec/Staging/<TopicName>/
+├── topic.md
+├── <TopicName>_spec.md
+└── <TopicName>_task.md
 ```
 
-### 3. Create specs.md
-```markdown
-# Design: <TopicName>
+For nested topics like `auth/login`, slashes are replaced with `-` in filenames: `auth-login_spec.md`, `auth-login_task.md`.
 
-## Overview
-> What does this feature do, and why is it needed?
+## Definition of done
 
-## Requirements
-- REQ-1: [Requirement statement - use SHALL/SHOULD for clarity]
-
-## Scenarios
-### Scenario 1
-- **Given** [precondition]
-- **When** [action]
-- **Then** [expected outcome]
-
-## Acceptance Criteria
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Technical Decisions
-- **Tooling**: [What libraries/frameworks to use]
-- **Trade-offs**: [Justification for choices]
-```
+- `topics_show` lists all three files (`topic.md`, `<TopicName>_spec.md`, `<TopicName>_task.md`).
+- The spec contains at least one `REQ-*` row and at least one example.
+- The task file has only implementation tasks, no test tasks.
+- `queue_check` returns `ready: true`.
 
 ## Output
+
 ```
-✅ Spec created: spec/Staging/<TopicName>/specs.md
-Next: /osdd:build <TopicName> to implement
+✓ Topic created at spec/Staging/<TopicName>/
+✓ Queue updated (Staging/queue.md)
+Next: /osdd:build <TopicName>
 ```

--- a/.agent/workflows/osdd:verify.md
+++ b/.agent/workflows/osdd:verify.md
@@ -1,86 +1,125 @@
 ---
-description: Verify implementation matches specification
+description: Trace every requirement in the spec to code in the repo; record evidence
 ---
 
 # /osdd:verify
 
-Verify that implementation matches the specification. Trace each requirement to code.
+Verify that the implementation matches the spec. Trace each `REQ-*` to code, with file:line evidence.
+
+The `osdd:` prefix is historical. This workflow runs against the UniSpec MCP server; the binary is `unispec`.
 
 ## Usage
 ```
-/osdd:verify <TopicName> [Working|Build]
+/osdd:verify <TopicName> [Working|Testing|Build]
 ```
+Default area: `Testing`.
 
 ## Rules
-1. **Be thorough** - Check every REQ-*
-2. **Show evidence** - Cite file and line number
-3. **Don't assume** - If not found, mark as missing
-4. **Distinguish partial** - Similar but not exact is partial
 
-## Status Meanings
+1. **Be thorough.** Check every `REQ-*` in the spec.
+2. **Show evidence.** Cite `<file>:<line>` for every status.
+3. **Don't assume.** If the code isn't found, mark `✗ missing`.
+4. **Distinguish partial.** "Similar but not exact" is `⚠ partial`, not `✓`.
+
+## Status meanings
+
 | Status | Meaning |
 |--------|---------|
-| ✓ Implemented | Code exists and matches spec |
-| ⚠ Partial | Partially implemented or different |
-| ✗ Missing | Not found in codebase |
+| `✓ implemented` | Code exists and matches the requirement. |
+| `⚠ partial` | Partially implemented or behaviorally different. |
+| `✗ missing` | Not found anywhere in the repo. |
+
+## Tools
+
+MCP:
+- `unispec_read_spec { topic, area }`
+- `read_asset { topic, asset_type: "spec", area }`
+- `index_list { topic }`
+- `index_find { query, by: "topic" | "path" | "tag" }`
+- `index_backlinks { topic }`
+- `notes_add { topic, note }`
+- `topics_push { topic, area }`
+- `task_status { topic, area, status }`
+
+CLI:
+- `unispec auto verify <topic>` — runs the configured verifier (if present).
+- `unispec index callers <symbol>` — find references; CLI only, not MCP.
 
 ## Steps
 
-### 1. Locate Files
-- Spec: `spec/<Area>/<TopicName>/specs.md`
-- Implementation: Search `src/` or use `osdd index find --topic <TopicName>`
-
-### 2. Extract Requirements
-From specs.md, list all `REQ-*` items:
-```markdown
-## Requirements
-- REQ-1: System SHALL do X
-- REQ-2: System SHOULD do Y
+### 1. Load the spec
+```
+unispec_read_spec { topic: "<TopicName>", area: "<Area>" }
+index_list        { topic: "<TopicName>" }
 ```
 
-### 3. Trace Each Requirement
-For each REQ-*:
-1. Search codebase for relevant code
-2. Check if it matches the requirement
-3. Record status with evidence
+### 2. Extract requirements
+From the spec's Requirements table, list every `REQ-*` ID.
 
-### 4. Generate Report
-```markdown
-# Verification Report: <TopicName>
+### 3. Trace each requirement
+For each `REQ-NNN`:
+- From `index_list`, identify candidate files (filter `link_type: "implementation"`).
+- Read those files; locate the code that implements (or should implement) the requirement.
+- Record state and evidence: `<file>:<line>`.
 
-## Coverage
-| REQ | Status | Evidence |
-|-----|--------|----------|
-| REQ-1 | ✓ | src/auth.ts:42 |
-| REQ-2 | ✗ | Not found |
+### 4. Run the verifier (if configured)
+```bash
+unispec auto verify <TopicName>
+```
+Combine its output with your manual trace.
 
-## Summary
-3/4 requirements verified (75%)
+### 5. Report
+```
+notes_add {
+  topic: "<TopicName>",
+  note: "Verification YYYY-MM-DD\n\n## Coverage\n| REQ | Status | Evidence |\n|-----|--------|----------|\n| REQ-001 | ✓ | src/auth/login.rs:42 |\n| REQ-002 | ✗ | not found |\n| REQ-003 | ⚠ | src/auth/login.rs:88 — locks after 10 failures, spec says 5 |\n\n## Summary\nN/M requirements verified."
+}
 ```
 
-## Output Formats
+### 6. Route (only if user added `--fix`)
+- If any `✗` or `⚠`:
+  ```
+  topics_push { topic: "<TopicName>", area: "Fixing" }
+  task_status { topic: "<TopicName>", area: "Fixing", status: "working" }
+  ```
+  Then close the gaps in `src/`, flip checkboxes, and:
+  ```
+  topics_push { topic: "<TopicName>", area: "Testing" }
+  task_status { topic: "<TopicName>", area: "Testing", status: "complete" }
+  ```
 
-### All Pass
+## Definition of done
+
+- Every `REQ-*` in the spec has a recorded state with `<file>:<line>` evidence.
+- The verification block is appended via `notes_add`.
+- With `--fix`: all gaps closed, topic returned to `Testing`, `task_status: complete`.
+- Without `--fix`: gaps are reported by `REQ-*` ID; the topic remains in its current area.
+
+## Output formats
+
+### All pass
 ```
 ✓ Verification Complete: <TopicName>
 Coverage: 5/5 (100%)
 All requirements verified.
-Ready for Build.
+Ready for /osdd:test or push to Build.
 ```
 
-### With Gaps
+### With gaps
 ```
 ✓ Verification Complete: <TopicName>
 Coverage: 4/5 (80%)
 
-✗ REQ-3: Feature not implemented
-  Recommendation: Add user preference storage
+✗ REQ-003: Feature not implemented
+  Evidence: not found
+  Recommendation: implement user preference storage
 
-⚠ REQ-4: Partial implementation
-  Found: logs with redaction
-  Expected: no password logging at all
+⚠ REQ-004: Partial implementation
+  Evidence: src/auth/login.rs:88
+  Found: 10-failure lockout; spec says 5.
 
 Options:
-1. /osdd:build <TopicName> to fill gaps
-2. Update spec to remove requirement
+1. /osdd:build <TopicName>     # add work to close the gaps
+2. Update the spec             # if 10 is correct, change REQ-004
+3. /osdd:verify --fix          # repair now, return to Testing
 ```

--- a/.agent/workflows/spec.md
+++ b/.agent/workflows/spec.md
@@ -1,94 +1,109 @@
 # Workflow: /spec
 
-**YOUR ONLY JOB: Create specs and tasks using the templates. Don't write code.**
+Create or refine a topic, spec, and task list in `Staging`. No code is written here.
+
+This workflow uses the UniSpec MCP tools. Tool names are literal; arguments are JSON objects.
 
 ---
 
-## 🔴 STRICT RULE: READ TEMPLATES FIRST!
+## Tools
 
-**Before creating any topic, spec, or task, you MUST read the template files first.**
-
-The templates are located in:
-- `.agent/modes/default/templates/topic.md`
-- `.agent/modes/default/templates/spec.md`
-- `.agent/modes/default/templates/task.md`
-- `.agent/modes/default/templates/area.md`
-
-Use `read_asset` to read these templates, then fill them in with actual content.
+| Tool | Required args | Purpose |
+|------|---------------|---------|
+| `read_asset` | `topic, asset_type` | Read templates (`topic: "templates"`) or existing topic/spec/task. `asset_type ∈ {"topic","spec","task"}`. |
+| `topics_add` | `topic, area, short, content` | Create `topic.md`. `content` ≥ 10 chars. Server writes frontmatter — don't include `---`. |
+| `spec_add` | `topic, area, short, spec_content, task_content` | Create `<topic>_spec.md` and `<topic>_task.md`. Both content fields ≥ 10 chars. Server strips your frontmatter and writes its own. |
+| `queue_add` | `topic, area` | Add the topic to `spec/<area>/queue.md` so BUILD can later push it. |
+| `topics_show` | `topic, area` | Verify files exist after creation. |
 
 ---
 
-## HOW TO USE THE TOOLS
+## Steps
 
-### Step 1: Read the Topic Template
-
+### 1. Read templates first
 ```
-read_asset {
-  topic: "templates",
-  asset_type: "topic",
-  area: "default"
-}
+read_asset { topic: "templates", asset_type: "topic" }
+read_asset { topic: "templates", asset_type: "spec" }
+read_asset { topic: "templates", asset_type: "task" }
 ```
+Mirror the section headings exactly. Fill the body with project-specific content — never commit `[placeholder]` text.
 
-Then create a topic using topics_add with the template structure:
-
+### 2. Create the topic
 ```
 topics_add {
-  topic: "myproject",
+  topic: "<topic-name>",
   area: "Staging",
-  short: "A web application for managing tasks and projects",
-  content: "[Use the topic template structure - fill in ALL sections with real content]"
+  short: "<one-line description>",
+  content: "<body matching templates/topic.md, with real content in each section>"
 }
 ```
 
-**IMPORTANT**: 
-- `content` parameter is REQUIRED and must have at least 20 characters of actual content
-- `short` parameter is REQUIRED for TUI display
-- The MCP tool will auto-add frontmatter - just provide the body content
+Constraints: `short` non-empty, `content` ≥ 10 chars, no leading `---` block (server writes its own frontmatter).
 
----
-
-### Step 2: Read the Spec and Task Templates
-
-```
-read_asset {
-  topic: "templates",
-  asset_type: "spec",
-  area: "default"
-}
-```
-
-Then create a spec + tasks using spec_add:
-
+### 3. Create the spec and task files
 ```
 spec_add {
-  topic: "myproject/auth",
+  topic: "<topic-name>",
   area: "Staging",
-  short: "User authentication with JWT tokens",
-  spec_content: "[Use the spec template structure - fill in ALL sections with real content]",
-  task_content: "[Use the task template structure - fill in ALL sections with real content]"
+  short: "<one-line description>",
+  spec_content: "<body matching templates/spec.md, sections filled>",
+  task_content: "<body matching templates/task.md, implementation tasks only>"
 }
 ```
 
+Filenames produced (slashes/spaces in `topic` become `-`):
+- `<topic>_spec.md`
+- `<topic>_task.md`
+
+### 4. Register in the queue
+```
+queue_add { topic: "<topic-name>", area: "Staging" }
+```
+
+### 5. Verify
+```
+topics_show { topic: "<topic-name>", area: "Staging" }
+```
+Must list `topic.md`, `<topic>_spec.md`, `<topic>_task.md`.
+
 ---
 
-## KEY POINTS
+## Content rules
 
-1. **Read templates first** - Don't guess the structure, read the template files
-2. **Follow template exactly** - Don't change the structure
-3. **Fill in all placeholders** - Write actual content in each section
-4. **No testing tasks** - The task template only has 4 phases (Foundation, Core Features, Integration, Polish)
-5. **Use MCP tools** - topics_add and spec_add will auto-add frontmatter including `short`
-6. **ALWAYS include `short` parameter** - This is required for the TUI display!
-7. **Use `spec_content`** - Use `spec_content` NOT `content` for spec_add!
-8. **content is REQUIRED** - topics_add requires meaningful content (20+ characters)
+- **Spec = WHAT, not HOW.** Use SHALL/SHOULD; acceptance criteria are checkable.
+- **Tasks = implementation steps only.** No test tasks here — those are added during BUILD.
+- **One topic = one bounded scope.** If you list five unrelated capabilities, split into sub-topics (`feature/sub-a`, `feature/sub-b`). The parent topic must already exist before adding a sub-topic.
+- **No placeholder strings in the body.** `[Requirement statement]`, `[Foundation task]`, etc. exist in templates to be replaced.
 
 ---
 
-## ASK IF UNSURE
+## Definition of done
 
-If you don't know what to write, ASK the user:
-- "What should this feature do?"
-- "What are the must-have requirements?"
-- "What does success look like?"
-- "What's a one-line description for this?"
+- `spec/Staging/<topic>/topic.md` exists with a real Overview.
+- `spec/Staging/<topic>/<topic>_spec.md` exists with every template section filled with real content.
+- `spec/Staging/<topic>/<topic>_task.md` exists with at least one concrete implementation task and zero test tasks.
+- `queue_check { topic, area: "Staging" }` returns `ready: true`.
+
+If any condition fails, the topic is not ready for `/build`.
+
+---
+
+## Failure modes
+
+- **`topics_add` errors with "content too short"** — `content` is under 10 chars or empty. Write a real body.
+- **`spec_add` errors with "spec_content required"** — you passed `content` instead. The parameter name is `spec_content` (not `content`) for `spec_add`.
+- **`spec_add` errors on nested topic** — the parent topic doesn't exist. Run `topics_add` for the parent first (e.g. `topics_add { topic: "auth", ... }` before `spec_add { topic: "auth/login", ... }`).
+
+---
+
+## Asking the user
+
+If you don't know any of these, ask before writing anything:
+
+- One-line description (`short`)
+- What problem does this solve, and for whom?
+- What are the must-have requirements (REQ-001, REQ-002, …)?
+- What is explicitly out of scope?
+- What's a checkable acceptance criterion?
+
+A vague answer means you ask again. Do not guess and commit.

--- a/.agent/workflows/test.md
+++ b/.agent/workflows/test.md
@@ -1,17 +1,91 @@
-# Workflow: Test
+# Workflow: /test
 
-## Purpose
-Run build scripts, test suites, and security checks to verify the implementation.
+Run the project's build and test pipeline for a topic in the `Testing` area. Promote on success; route to `Fixing` on failure.
 
-## Process
-1. **Context Loading**: Identify the topic and area.
-2. **Build Execution**: Run the configured build command.
-3. **Test Execution**: Run the configured test command.
-4. **Verification**: 
-   - If successful: Report success and prompt for promotion to Build.
-   - If failed: Report errors, identify the failing test/build, and suggest running `/verify --fix`.
+`/test` does not modify code. It only runs scripts and reports results.
 
-## Agent Instructions
-- Use `unispec auto test` to execute the pipeline.
-- If the build fails, do not attempt to fix it automatically. Report the error and wait for the user to trigger `/verify --fix`.
-- Ensure all test output is captured in the report.
+---
+
+## Tools
+
+MCP tools used:
+- `topics_list { area: "Testing" }` — list topics ready to test.
+- `unispec_read_spec { topic, area: "Testing" }` — context, especially for which connector to run.
+- `notes_add { topic, note }` — record the test run result.
+- `topics_push { topic, area }` — promote to `Build` on success or `Fixing` on failure.
+- `task_status { topic, area, status }` — mark `complete` on promotion, `working` on rollback.
+- Any `unispec_<connector>` MCP tool defined in `.agent/config.toml` (e.g. `unispec_test`, `unispec_build`, `unispec_lint`).
+
+CLI tools used (shell out — not MCP):
+- `unispec auto test [-t <topic>]` — runs the configured pre/test/post scripts.
+
+---
+
+## Steps
+
+### 1. Identify the topic
+```
+topics_list       { area: "Testing" }
+unispec_read_spec { topic: "<topic>", area: "Testing" }
+```
+Note which connectors are referenced in the spec (build, test, lint, etc.).
+
+### 2. Run the pipeline
+
+Preferred — invoke configured connectors via MCP:
+```
+unispec_build  { args: [] }
+unispec_test   { args: [] }
+unispec_lint   { args: [] }   # only if defined
+```
+
+Or shell out:
+```bash
+unispec auto test -t <topic>
+```
+
+Capture the full stdout/stderr and the exit code.
+
+### 3. Report
+
+```
+notes_add {
+  topic: "<topic>",
+  note: "Test run YYYY-MM-DD:\n- build: <pass|fail>\n- test: <pass|fail>\n- lint: <pass|fail>\n<first 20 lines of failing output, if any>"
+}
+```
+
+### 4. Route
+
+**On all green:**
+```
+task_status { topic: "<topic>", area: "Testing", status: "complete" }
+topics_push { topic: "<topic>", area: "Build" }
+```
+
+**On any failure:**
+```
+topics_push { topic: "<topic>", area: "Fixing" }
+task_status { topic: "<topic>", area: "Fixing", status: "working" }
+```
+Do **not** attempt to fix the code yourself in this workflow. `/verify --fix` owns the repair loop. Tell the user which step failed and hand off.
+
+---
+
+## Definition of done
+
+`/test` is done when:
+- Every configured pipeline step (build, test, optionally lint/typecheck) has run for the topic.
+- The result of each step is captured via `notes_add`.
+- The topic has been pushed into either `Build` (all green) or `Fixing` (any red).
+- `task_status` matches the new area (`complete` for Build, `working` for Fixing).
+
+If you ran a partial pipeline because a step blocked the next, say so explicitly in the `notes_add` body and leave the topic in `Testing`.
+
+---
+
+## Failure modes
+
+- **`unispec_<connector>` not found** — the connector isn't defined; check `.agent/config.toml`. Fall back to shelling out to the underlying command if the user authorizes it.
+- **Connector timeout** — exit code reflects the timeout, not a real failure. Mention this in the note and ask the user before routing to Fixing.
+- **No connectors configured at all** — there's nothing to run automatically. Read the spec to find a manual test plan, run it via host shell, and report results via `notes_add`.

--- a/.agent/workflows/verify.md
+++ b/.agent/workflows/verify.md
@@ -1,27 +1,98 @@
 # Workflow: /verify
 
-## Purpose
-Verify the alignment between the specification and the implementation. This workflow can be triggered at any stage to ensure quality and consistency.
+Confirm that the implementation in `src/` matches every requirement in the spec for a topic.
 
-## Process
-1. **Context Loading**:
-   - Read `spec.md` and `task.md` for the current topic.
-   - Use `unispec index list --topic <topic>` to identify bound files.
+`/verify` is read-mostly. If `--fix` is requested, the failing topic is pulled into `Fixing`, the issue is addressed, and the topic returns to `Testing`.
 
-2. **Alignment Check**:
-   - Run `unispec auto verify <topic>`.
-   - Analyze the output for mismatches between requirements and implementation.
+---
 
-3. **Relationship Check**:
-   - Use `unispec index callers <symbol>` for key functions to ensure no regressions were introduced in dependent modules.
+## Tools
 
-4. **Fixing (If --fix tag is present)**:
-   - If issues are found, move the topic to the `Fixing` area.
-   - Analyze failure logs or alignment issues.
-   - Apply fixes to the code.
-   - Update `task.md` notes with the fix details.
-   - Return to `Testing` area.
+MCP tools used:
+- `unispec_read_spec { topic, area }` — load spec + task.
+- `read_asset { topic, asset_type: "spec", area }` — re-read just the spec when needed.
+- `index_list { topic }` — list every file linked to the topic.
+- `index_find { query, by }` — `by ∈ {"topic","path","tag"}`.
+- `index_backlinks { topic }` — find which other topics depend on this one (helpful for regression scoping).
+- `notes_add { topic, note }` — record verification findings.
+- `topics_push { topic, area }` — move into `Fixing` (only with `--fix`).
+- `task_status { topic, area, status }` — update `status:` to `pending` if you're sending it back to Fixing.
 
-5. **Reporting**:
-   - Update `topic.md` with the verification status (aligned/misaligned).
-   - If misaligned, list specific issues in the `Verification Summary` section.
+CLI tools used (shell out — not MCP):
+- `unispec auto verify <topic>` — runs the configured verification script for the topic.
+
+---
+
+## Steps
+
+### 1. Load context
+```
+unispec_read_spec { topic: "<topic>", area: "<Testing or Working>" }
+index_list        { topic: "<topic>" }
+```
+The spec gives you the list of `REQ-*` items. `index_list` tells you which files claim to implement them.
+
+### 2. Trace each requirement to code
+
+For each `REQ-NNN` in the spec:
+- Identify the linked file(s) most likely to implement it (from `index_list`, filter by `link_type: "implementation"`).
+- Read those files with the host editor's Read tool.
+- Record one of three states for each requirement:
+  - `✓ implemented` — code matches the requirement.
+  - `⚠ partial` — partial or different from spec.
+  - `✗ missing` — not found.
+
+Cite evidence with `<file>:<line>` so the user can verify.
+
+### 3. Run the configured verifier (optional)
+
+If a verifier is configured for this project:
+```bash
+unispec auto verify <topic>
+```
+Parse its output. Combine with your manual trace.
+
+### 4. Check regressions on dependents
+```
+index_backlinks { topic: "<topic>" }
+```
+If other topics depend on this one, re-check their critical paths still work.
+
+### 5. Produce the report
+
+Append a verification block to the topic's notes:
+```
+notes_add {
+  topic: "<topic>",
+  note: "Verification YYYY-MM-DD: <N>/<M> requirements implemented.\n- REQ-001 ✓ src/auth/login.rs:42\n- REQ-002 ✗ not found\n- REQ-003 ⚠ partial — src/auth/login.rs:88 (locks after 10 failures, spec says 5)"
+}
+```
+
+### 6. If `--fix` was requested and there are gaps
+```
+topics_push  { topic: "<topic>", area: "Fixing" }
+task_status  { topic: "<topic>", area: "Fixing", status: "working" }
+```
+Address each gap in `src/`, update `tasks_complete` / `notes_add`, then push back to Testing:
+```
+topics_push  { topic: "<topic>", area: "Testing" }
+task_status  { topic: "<topic>", area: "Testing", status: "complete" }
+```
+
+---
+
+## Definition of done
+
+`/verify` is done when:
+- Every `REQ-*` in the spec has a recorded state (`✓` / `⚠` / `✗`) with file:line evidence.
+- The verification block is recorded via `notes_add`.
+- If `--fix` was requested, gaps are addressed and the topic is back in `Testing` with `task_status: complete`.
+- If `--fix` was not requested and gaps exist, the user has been told exactly which `REQ-*` IDs are unimplemented, and the topic has **not** been advanced.
+
+---
+
+## Failure modes
+
+- **`unispec_read_spec` returns empty content** — the topic isn't in this area, or the spec file was renamed manually. Run `topics_show { topic, show_all: true }` to locate it.
+- **`index_list` returns no entries** — code was written but never linked. Either link the files via `index_add` (catch-up indexing) or report this as a structural failure for the BUILD step.
+- **Verifier exits non-zero with no `REQ-` mapping** — the verifier failed before producing a report; don't push to Fixing automatically, ask the user.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,128 +1,106 @@
-# Contributing to OpenSDD
+# Contributing to UniSpec
 
-Thank you for your interest in contributing to OpenSDD! This document outlines how you can help.
+Thanks for your interest in contributing. This document covers the practical ways to help.
 
-## Ways to Contribute
+## Ways to contribute
 
-### 1. Create a Mode
+### 1. Create a mode
 
-Modes are the heart of OpenSDD. Create your own:
+Modes are the heart of UniSpec — they define the area pipeline, workflow prompts, and templates an agent uses. Layout:
 
-```bash
-# Structure
-.agent/modes/my-mode/
-├── mode.toml          # Required: Mode metadata
-├── skill.md          # Required: Agent persona
-├── workflows/        # Optional: Custom workflows
-│   ├── my:workflow.md
-├── areas/            # Optional: Area templates
-│   ├── staging/
-│   └── production/
-└── templates/        # Optional: Topic templates
-    ├── specs.md
-    └── tasks.md
+```
+.agent/modes/<mode-name>/
+├── mode.toml          # Required: metadata, areas, readiness rules, templates config
+├── skill.md           # Required: agent persona
+├── workflows/         # Optional: workflow prompts (spec.md, build.md, …)
+├── areas/             # Optional: per-area templates
+│   └── <area>/area.md
+└── templates/         # Optional: global fallback templates
+    ├── topic.md
+    ├── spec.md
+    ├── task.md
+    └── area.md
 ```
 
-See [Simple Mode documentation](../docs/simple-mode/) for details.
+See `.agent/modes/default/` for a complete working example and [docs/modes.md](docs/modes.md) for the full reference.
 
-### 2. Improve Documentation
+### 2. Improve documentation
 
-- Fix typos
-- Add examples
-- Write tutorials
-- Translate to other languages
+- Fix typos and broken links.
+- Add examples that map MCP tool calls to outcomes.
+- Clarify ambiguous prompts in `.agent/workflows/` or `.agent/modes/<mode>/`.
 
-### 3. Report Bugs
+When you touch a prompt that an agent will read, treat it as code: tool names must match `src/mcp/mod.rs::get_tools()`, and every workflow needs a clear definition of done.
+
+### 3. Report bugs
 
 When reporting bugs, include:
-- OS and version
-- Steps to reproduce
-- Expected vs actual behavior
-- OpenSDD version (`osdd --version`)
+- OS and version.
+- Steps to reproduce.
+- Expected vs actual behavior.
+- `unispec --version` output.
 
-### 4. Feature Requests
+### 4. Feature requests
 
-We love feature requests! Please describe:
-- The problem you're solving
-- How you envision it working
-- Any existing workarounds
+Describe:
+- The problem you're solving.
+- How you envision it working.
+- Any existing workarounds.
 
-### 5. Code Contributions
+### 5. Code contributions
 
-1. Fork the repository
-2. Create a branch: `git checkout -b feature/my-feature`
-3. Write specs for your changes first
-4. Implement with tests
-5. Submit a PR
+1. Fork the repo.
+2. Create a branch: `git checkout -b feat/<short-description>`.
+3. If your change affects user-facing behavior, write or update a spec first (use `/spec` or the MCP tools directly).
+4. Implement with tests where applicable.
+5. Open a PR.
 
-## Development Setup
+## Development setup
 
 ```bash
-# Clone the repo
-git clone https://github.com/yourname/osdd.git
-cd osdd
+git clone https://github.com/uwzis/UniSpec.git
+cd UniSpec
 
-# Build
 cargo build
-
-# Run tests
 cargo test
-
-# Run with your changes
 cargo run -- --help
 ```
 
-## Code Style
+## Code style
 
-- Run `cargo fmt` before committing
-- Run `cargo clippy` to catch common mistakes
-- Add comments for non-obvious code
-- Write specs for new features
+- Run `cargo fmt` before committing.
+- Run `cargo clippy` — fix or justify every warning.
+- Add comments only when the *why* isn't obvious from the code.
+- Update specs and docs when behavior changes.
 
-## Commit Messages
+## Commit messages
 
 Format:
+
 ```
 type: short description
 
-longer explanation if needed
+(optional) longer explanation
 
 Fixes #123
 ```
 
-Types:
-- `feat:` New feature
-- `fix:` Bug fix
-- `docs:` Documentation
-- `refactor:` Code refactoring
-- `test:` Adding tests
-- `chore:` Maintenance
+Types: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.
 
-## Pull Request Process
+## Pull request checklist
 
-1. Update README if needed
-2. Add tests for new features
-3. Ensure all tests pass
-4. Update documentation
-5. Request review
+- [ ] Tests pass: `cargo test`.
+- [ ] No clippy warnings: `cargo clippy --all-targets --all-features -- -D warnings`.
+- [ ] Public API or CLI changes are reflected in `docs/`.
+- [ ] If you added or renamed an MCP tool, `docs/mcp.md` and the agent prompts in `.agent/` are updated.
+- [ ] If you added a connector, sample example is in `docs/configuration.md`.
 
-## Patty's Contribution Tips
+## Code of conduct
 
-> "Every contribution starts with a spec. Even contributions to the spec tool should have specs."
-
-- Write a spec for your contribution
-- Keep PRs focused and small
-- Respond to feedback constructively
-- Test your changes manually
-
-## Code of Conduct
-
-Be respectful. Be helpful. Be kind to Patty.
+Be respectful. Be helpful. Be kind to Paddy.
 
 ## Questions?
 
-- Open an issue
-- Join the discussion
+- Open an issue: <https://github.com/uwzis/UniSpec/issues>
+- Browse discussions on the repo
 - Email the maintainers
-
-Thank you for making OpenSDD better! 🦫

--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ unispec
 
 ## Core Concepts 🔥
 
-### Areas (Simple Mode)
+### Areas (Default Mode)
 
 | Area | Purpose |
 |------|---------|
 | **Staging** | Writing specs |
-| **Building** | Writing code |
-| **Ship** | Done. Ready to deploy. |
+| **Working** | Writing code |
+| **Testing** | Running build & test pipelines |
+| **Fixing** | Repairing issues from Testing |
+| **Build** | Done. Treated as immutable. |
 
 ### Indexing (The Secret Sauce)
 
@@ -91,10 +93,7 @@ unispec index add --topic "user-login" --path tests/login_test.py
 
 ### Modes
 
-Custom workflows for different teams:
-- `.agent/modes/simple/` - Default (spec → build → ship)
-- `.agent/modes/complex/`- Advanced workflows
-- `.agent/modes/ingest/` - Create specs from code
+Custom workflows for different teams. The default mode ships at `.agent/modes/default/` and uses the five-area pipeline above. Additional modes (sprint, kanban, RFC, docs) can be installed from the community package repository or built by hand — see [docs/modes.md](docs/modes.md).
 
 ---
 

--- a/docs/agent-system-prompt.md
+++ b/docs/agent-system-prompt.md
@@ -1,157 +1,114 @@
 # Skill: UniSpec Agent
 
 ## Persona
-You are a Senior Software Developer and UniSpec Workflow Orchestrator. Your expertise spans spec-driven development, code implementation, and verification. You work with the user to move ideas through the full development pipeline from planning to deployment.
+You are a Senior Software Developer and UniSpec Workflow Orchestrator. You drive a spec-first development pipeline using the UniSpec MCP server. You create topics, specs, and tasks, link code files to specs, move work through areas, and verify implementations against specifications.
 
 ## Core Objective
-Your goal is to help the user transform ideas into working code through the UniSpec spec-driven workflow. You create topics, specs, and tasks. You link code files to specs. You move work through areas. You verify implementations against specifications.
+Transform ideas into shipped code by walking each topic through the UniSpec pipeline: Staging → Working → Testing → Fixing → Build.
 
-## Operational Constraints
-- **Conditional File Writing**: You do not create, modify, or delete project files (spec.md, task.md, code files, etc.) until specifically instructed to do so by the user. Wait for explicit instruction before creating or editing any files.
-- **MCP-First**: Use the MCP tools provided by the UniSpec server for all spec, topic, task, and index operations. Only use direct file tools (read, edit, write) when MCP tools cannot accomplish the task.
-- **Spec-Driven**: Always reference the spec before writing code. Use `unispec_read_spec` to understand requirements.
-- **Task Tracking**: Use task tools (`tasks_list`, `tasks_complete`, `tasks_incomplete`) to track progress through the spec.
-- **Index Linking**: Use `index_add` to link code files to specs so relationships are tracked.
-- **Queue Management**: Use the queue tools to maintain an ordered list of work to be done.
+## Hard Rules (always apply)
 
-## Workflow Protocol
+1. **Use the MCP tools listed below.** Do not invent tool names. If a tool you want is not in the list, fall back to the file Read/Write tools your host editor provides.
+2. **Do not write files into topic directories with Read/Write tools.** Topic frontmatter and filenames are managed by `topics_add`, `spec_add`, `spec_write`, and `task_write`. Bypassing them corrupts the index.
+3. **Read the spec before coding.** Use `unispec_read_spec` (or `read_asset`) to load the full spec.md + task.md for the topic before touching code.
+4. **Mark tasks complete as you go.** Call `tasks_complete` immediately after finishing a task; do not batch.
+5. **Link every new code file.** Call `index_add` whenever you create or substantially edit a code file so the spec ↔ code relationship is tracked.
 
-### 5 Areas (Pipeline Stages)
-1. **Staging** - New ideas and initial specs (planning/architecture)
-2. **Working** - Active development and implementation
-3. **Testing** - Code verification and testing
-4. **Fixing** - Resolving issues and bugs
-5. **Build** - Ready for final build/deployment
+## The 5 Areas
 
-### 4 Modes
+| Area | Purpose | Default |
+|------|---------|---------|
+| Staging | Specs being written and refined | yes (default for new topics) |
+| Working | Active implementation | |
+| Testing | Build/test/verification runs | |
+| Fixing | Debugging issues found in Testing | |
+| Build | Verified, shippable; treat as immutable | |
 
-#### PLAN Mode (Planning)
-- Default mode for discussion and analysis
-- Does NOT create or modify any files
-- Use `areas_list` to see available areas
-- Use `topics_list` to see what exists in each area
-- Use `unispec_read_spec` to review existing specs
-- Use `topics_progress` to see completion status
-- Use `queue_list` to see prioritized work
-- Use `index_find` to trace existing implementations
-- Analyze specs and help work through technical challenges
+`spec/<Area>/queue.md` lists topics that are ready to push. A topic can only be pushed out of Staging or Fixing if it is listed in that area's `queue.md`.
 
-#### SPEC Mode (Specification)
-- Creating, modifying, and arranging topics, specs, and tasks
-- Use `topics_add` to create new topics
-- Use `unispec_read_spec` to read current specs
-- Use `tasks_list` to view tasks for a topic
-- Use `tasks_complete`/`tasks_incomplete` to update task status
-- Use `notes_add` to add implementation notes to task.md
-- Use `notes_read` to review notes
-- Use `index_add` to link files to specs as you plan
-- Use `index_find` to see what already exists
-- Use `topics_push` to move completed specs to next area
+## Available MCP Tools (ground truth)
 
-#### BUILD Mode (Implementation)
-- Converting specs into actual code
-- Use `unispec_read_spec` to review requirements before coding
-- Use `tasks_list` to see what needs to be done
-- Use `tasks_complete` as you finish items
-- Use `notes_add` to record implementation decisions
-- Use `index_add` to link new files to the spec
-- Use `index_find` to find related files
-- Use `topics_push` to move to Testing when complete
+These are the only tools the MCP server publishes. Anything not in this list does not exist as an MCP tool.
 
-#### VERIFY Mode (Validation)
-- Running checks against Spec vs Code
-- Use `index_graph` to see all linked files and relationships
-- Use `index_find` to trace file connections to specs
-- Use `index_backlinks` to see what references a spec
-- Use `unispec_read_spec` to compare against implementation
-- Use `topics_progress` to see overall completion
-- Fix issues or push to next area
+### Area & topic management
+- `areas_list` — `{}` — list all areas.
+- `topics_list {area?}` — list topics in an area. Default area: `Staging`.
+- `topics_add {topic, area, short, content}` — **all four are required**. `short` is a one-line description. `content` must be ≥ 10 characters of actual body text. The server prepends `---` frontmatter (`title`, `short`, `created`, `author`); do not include frontmatter in `content`.
+- `topics_show {topic, area?}` — show files in a topic directory.
+- `topics_delete {topic, area?, force?}` — delete a topic.
+- `topics_push {topic, area, source_area?}` — move a topic to another area. If source is Staging or Fixing, the topic must be in that area's `queue.md` first.
+- `topics_pull {topic, source_area}` — pull a topic from another area into Working.
+- `topics_progress {area?}` — per-topic completion counts in an area.
 
-## Available MCP Tools
+### Asset reading
+- `read_asset {topic, asset_type, area?}` — read a file. `asset_type` is `"topic"`, `"spec"`, or `"task"`. Special case: `topic: "templates"` reads from `.agent/modes/default/templates/`.
+- `unispec_read_spec {topic, area?}` — return both spec and task content for a topic in one call.
 
-### Area & Topic Management
-- `areas_list` - List all areas
-- `topics_list [area]` - List topics in an area (default: Working)
-- `topics_add {topic, area}` - Create a new topic
-- `topics_delete {topic, area, force}` - Delete a topic
-- `topics_show {topic, area}` - Show topic details
-- `topics_push {topic, area, source_area}` - Move topic to another area
-- `topics_pull {topic, source_area}` - Pull topic from another area into Working
-- `topics_progress [area]` - Show progress across topics
-
-### Spec & Task Reading
-- `unispec_read_spec {topic, area}` - Read spec.md and task.md content
-
-### Task Management
-- `tasks_list {topic, area}` - List all tasks with status
-- `tasks_complete {topic, task_index, note, area}` - Mark task complete (index is 0-based)
-- `tasks_incomplete {topic, task_index, note, area}` - Mark task incomplete
+### Spec & task writing
+- `spec_add {topic, area, short, spec_content, task_content}` — **all five required**. Creates `<topic>_spec.md` and `<topic>_task.md` (slashes and spaces in `topic` are replaced with `-`). Server strips any frontmatter you include and prepends its own. Both content fields need ≥ 10 characters.
+- `spec_write {topic, area?, content}` — overwrite an existing topic's spec file.
+- `task_write {topic, area?, content}` — overwrite the task file. **Fails** if the spec file does not exist for that topic.
+- `task_status {topic, status, area?}` — update the `status:` field in the task file's frontmatter. `status` must be one of `pending`, `working`, `complete`. This does **not** check off individual `- [ ]` items; edit the task content for that, or use `tasks_complete`.
+- `tasks_list {topic, area?}` — list task lines and their checkbox state.
+- `tasks_complete {topic, task_index, note?, area?}` — mark the task at 0-based `task_index` as `[x]`.
+- `tasks_incomplete {topic, task_index, note?, area?}` — mark a task back to `[ ]`.
 
 ### Notes
-- `notes_read {topic, area}` - Read notes section from task.md
-- `notes_add {topic, note, area}` - Add a note to task.md
+- `notes_read {topic, area?}` — read the notes section of the task file.
+- `notes_add {topic, note, area?}` — append a note to the task file's notes section.
 
-### Task Queue
-- `queue_list [area]` - List ordered queue of topics
-- `queue_add {topic, position, area}` - Add to queue (position 0=first, -1=last)
-- `queue_remove {topic, area}` - Remove from queue
-- `queue_reorder {topic, new_position, area}` - Reorder queue
+### Readiness queue
+- `queue_list {area?}` — show `spec/<area>/queue.md`.
+- `queue_add {topic, position?, area?}` — add to queue (`position: 0` = first, `-1` = last; default last).
+- `queue_remove {topic, area?}` — remove from queue.
+- `queue_check {topic, area?}` — returns `ready: true|false`.
+- `queue_reorder {topic, new_position, area?}` — move a topic in the queue.
 
-### Index (File ↔ Spec Linking)
-- `index_add {topic, path, area, link_type, tags, annotation}` - Link file to topic
-- `index_find {query, by}` - Find links by topic/path/tag
-- `index_lookup {id}` - Find export by full ID (topic:name)
-- `index_list [topic, path, tag]` - List all index links with filters
-- `index_graph` - Export full relationship graph JSON
-- `index_backlinks {topic}` - Generate backlinks for a topic
-- `unispec_bind_spec {spec_path, file_path, topic, area}` - Bind code file to spec
+### Index (file ↔ spec linking)
+- `index_add {topic, path, area?, link_type?, tags?, annotation?}` — link a file or directory to a topic.
+- `unispec_bind_spec {spec_path, file_path, topic, area?}` — record a file as bound to a spec.
+- `index_find {query, by?}` — `by`: `topic` (default), `path`, or `tag`.
+- `index_lookup {id}` — fetch an export by full `topic:name` ID.
+- `index_list {topic?, path?, tag?}` — list links with optional filters.
+- `index_graph {}` — return the full link graph as JSON.
+- `index_backlinks {topic}` — generate a backlinks markdown block for a topic.
 
-## Confirmation for File Operations
-The user must explicitly instruct you to create or modify files. When they want you to create spec.md, task.md, or any code files, they will tell you directly. Until then, use MCP tools to understand what exists and what needs to be done.
-
-## Example Workflow
+## File layout the tools create
 
 ```
-# Start: Check the queue and current work
-Agent: queue_list
-Agent: topics_progress {area: "Working"}
-
-# Pick a topic and read its spec
-Agent: unispec_read_spec {topic: "user-auth", area: "Working"}
-
-# See what tasks need doing
-Agent: tasks_list {topic: "user-auth", area: "Working"}
-
-# Do work, mark tasks complete
-Agent: tasks_complete {topic: "user-auth", task_index: 0}
-Agent: tasks_complete {topic: "user-auth", task_index: 1}
-
-# Add implementation note
-Agent: notes_add {topic: "user-auth", note: "Using bcrypt for password hashing"}
-
-# Link new implementation file to spec
-Agent: index_add {topic: "user-auth", path: "src/auth/login.rs", link_type: "implementation", tags: "auth,login"}
-
-# Move to Testing when done
-Agent: topics_push {topic: "user-auth", area: "Testing"}
-
-# Verify the work
-Agent: index_graph
-Agent: index_backlinks {topic: "user-auth"}
+spec/
+├── <Area>/
+│   ├── queue.md                    # readiness queue (managed by queue_*)
+│   └── <topic>/
+│       ├── topic.md                # written by topics_add
+│       ├── <topic>_spec.md         # written by spec_add / spec_write
+│       └── <topic>_task.md         # written by spec_add / task_write
 ```
 
-## Key Principles
+For a nested topic like `auth/login`, the directory is `spec/<Area>/auth/login/` and the files are `auth-login_spec.md` and `auth-login_task.md` (slash → dash).
 
-1. **Always use MCP tools first** - For all spec, topic, task, and index operations, use the MCP tools. Only fall back to direct file operations when MCP tools cannot do what you need.
+## Standard loop
 
-2. **Read the spec before coding** - Use `unispec_read_spec` to understand requirements before making any changes.
+1. `areas_list` and `topics_list {area: "Working"}` to orient.
+2. `queue_list {area: "Working"}` to pick the next topic.
+3. `unispec_read_spec {topic, area: "Working"}` to load full context.
+4. `tasks_list {topic, area: "Working"}` to see what's open.
+5. For each open task: do the work, then `tasks_complete {topic, task_index: N}`.
+6. `index_add {topic, path: "<file you wrote or changed>", link_type: "implementation"}`.
+7. `notes_add {topic, note: "<decision you made that isn't in the spec>"}` whenever you diverge from the literal spec.
+8. When every task is `[x]` and the topic is in `Working/queue.md`, call `topics_push {topic, area: "Testing"}`.
 
-3. **Track progress with tasks** - Mark tasks complete as you finish them so progress is visible.
+## Definition of done for an agent turn
 
-4. **Link files to specs** - Use `index_add` whenever you create or modify a file so the relationship is tracked.
+A turn is finished when:
+- Every task you touched is reflected in the task file (checkbox flipped via `tasks_complete`, status updated via `task_status` if you started/stopped work).
+- Every code file you wrote or changed is linked via `index_add`.
+- Any decision not in the spec is captured via `notes_add`.
+- If the next area transition is appropriate, you've either called `topics_push` or stated explicitly why you didn't.
 
-5. **Use the queue** - Maintain an ordered work list with `queue_list`/`queue_add` so priorities are clear.
+## What to do when something doesn't fit
 
-6. **Move work through areas** - Push topics to the next area when ready (Staging → Working → Testing → Fixing → Build).
-
-7. **Verify with the index** - Use `index_graph` and `index_backlinks` to understand the full picture before making changes.
+- If a required field is missing, ask the user — do not pass empty strings.
+- If `task_write` fails because no spec exists, call `spec_add` first with both `spec_content` and `task_content`.
+- If `topics_push` fails because the topic is not in the queue, call `queue_add` first.
+- If a tool you want isn't in the list above, say so explicitly and propose the closest available alternative — don't fabricate a tool call.

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -1,198 +1,149 @@
-# Skill: UniSpec BUILD Workflow
+# BUILD Workflow
 
-## Purpose
-This workflow is for implementing specs into code. Use this when converting specifications into working code.
+Use this workflow to implement a topic — convert a spec in Staging into working code in `src/`, and hand it off to Testing.
 
-**IMPORTANT: All work starts in Staging. A topic must be listed in area's queue.md to be pushable.**
-
----
-
-## KEY RULE: Topics First, Always!
-
-**Before doing ANYTHING, you MUST research topics first!**
-
-1. **ALWAYS start by listing topics** - Never assume you know what's being built
-2. **ALWAYS read the topic first** - Understand the scope before building
-3. **Topics define scope** - Each topic bounds what specs are being implemented
+This file assumes the MCP tools listed in `docs/mcp.md` are available. Tool names are literal; arguments are objects.
 
 ---
 
-## READINESS SYSTEM - IMPORTANT!
+## Preconditions
 
-A topic is ONLY ready to push if it is listed in the area's `queue.md` file (e.g., `Staging/queue.md`).
+- The topic already has both files: `<topic>_spec.md` and `<topic>_task.md` (created via `spec_add`).
+- The topic is listed in `spec/Staging/queue.md` (or you'll add it below — `topics_push` from Staging requires this).
+- `src/` exists at the project root. If not, create it once at the start.
 
-**Why?**
-- Prevents pushing topics that aren't ready
-- Ensures all work is tracked in the central to-do list
-- Queue is deleted when moving from Working → Testing
-
-**How to verify:**
-```
-# Check if topic is in the area queue
-queue_check {topic: "<topic-name>", area: "Staging"}
-```
-
-If `ready: true`, you can push. If `ready: false`, add it first:
-```
-queue_add {topic: "<topic-name>", area: "Staging"}
-```
+If any precondition isn't met, fix it before running the steps below.
 
 ---
 
-## The BUILD Workflow
+## Steps
 
-### Step 0: Research Topics FIRST
-1. **List all topics in Staging:**
+### 1. Orient
+
+```
+topics_list   { area: "Staging" }
+queue_list    { area: "Staging" }
+```
+
+If the topic isn't in the queue:
+
+```
+queue_add    { topic: "<topic>", area: "Staging" }
+queue_check  { topic: "<topic>", area: "Staging" }
+```
+
+`queue_check` must return `ready: true` before you can push.
+
+### 2. Push to Working
+
+```
+topics_push { topic: "<topic>", area: "Working" }
+```
+
+This copies the topic into `spec/Working/<topic>/` and leaves the original in Staging.
+
+### 3. Load the spec and tasks
+
+```
+unispec_read_spec { topic: "<topic>", area: "Working" }
+tasks_list        { topic: "<topic>", area: "Working" }
+task_status       { topic: "<topic>", area: "Working", status: "working" }
+```
+
+Read both before writing code. The full task list comes back ordered, with each item's 0-based index, text, and checkbox state.
+
+### 4. Implement, one task at a time
+
+For each open task at `task_index = N`:
+
+1. Write code into `src/` at the project root. **Code never goes inside `spec/`.**
+2. After saving the file, link it:
    ```
-   topics_list {area: "Staging"}
+   index_add {
+     topic: "<topic>",
+     path: "src/<file>",
+     link_type: "implementation",
+     tags: "<comma-separated>",
+     annotation: "<one line: what this file contributes>"
+   }
    ```
-
-2. **Read the topic:**
+3. Mark the task complete:
    ```
-   topic_read {topic: "<topic-name>", area: "Staging"}
+   tasks_complete { topic: "<topic>", task_index: N }
    ```
-
-### Step 1: Check Readiness FIRST
-**Before pushing anything, check if the topic is in the area queue:**
-
-```
-queue_check {topic: "<topic-name>", area: "Staging"}
-```
-
-If not ready, add it:
-```
-queue_add {topic: "<topic-name>", area: "Staging"}
-```
-
-**This is REQUIRED - you cannot push a topic that's not in the queue!**
-
-### Step 2: Find queue.md in Staging
-**Look for the area queue.md file in Staging to know what to build:**
-```
-queue_list {area: "Staging"}
-```
-
-The queue.md is the CENTRAL TO-DO LIST in the AREA (e.g., `Staging/queue.md`). It contains ALL topics that need to be built.
-
-### Step 3: Create /src FIRST
-**Before writing any code, create /src at project root:**
-```
-# At project root (same level as spec/)
-# Create src/ directory - ALL code goes here
-```
-
-### Step 4: Push the Topic to Working
-**Push a topic that is listed in the queue:**
-```
-topics_push {topic: "<topic-name>", area: "Working"}
-```
-
-This pushes the topic. The queue.md stays in Staging.
-
-### Step 5: Read queue.md in Working
-```
-queue_list {area: "Working"}
-```
-
-### Step 6: Build Each Topic in Order
-For each topic in the queue:
-
-1. **Read spec and task files:**
+4. If a decision wasn't in the spec, capture it:
    ```
-   spec_read {topic: "<topic-name>", area: "Working"}
-   task_read {topic: "<topic-name>", area: "Working"}
+   notes_add { topic: "<topic>", note: "<decision + reason>" }
    ```
 
-2. **Create code in /src** (NOT in topic directories)
+Do these four steps for every task before moving on. Do not batch them across tasks — `tasks_complete` is cheap, and stale checkboxes lose information.
 
-3. **Link every file:**
-   ```
-   index_add {topic: "<topic-name>", path: "src/filename.rs", link_type: "implementation", tags: "..."}
-   ```
+### 5. Add test tasks (BUILD phase only)
 
-4. **CHECK OFF TASKS IMMEDIATELY - THIS IS REQUIRED!**
-   After completing each task, mark it complete:
-   ```
-   task_write {topic: "<topic-name>", area: "Working", content: "..."}
-   ```
-   Change `- [ ]` to `- [x]` for completed tasks.
+Implementation tasks belong in the spec. **Test tasks belong here, after implementation is finished.** Append them to the task file:
 
-   **NEVER skip this step! Always check off completed tasks before moving to the next one.**
-
-### Step 7: Add Testing Tasks Before Pushing to Testing
-**Testing tasks are ONLY created here - AFTER all implementation is done:**
 ```
-task_read {topic: "<topic-name>", area: "Working"}
+task_write {
+  topic: "<topic>",
+  area: "Working",
+  content: "<full task file content including the original Implementation phases plus a new ### Phase 5: Testing section with each test as `- [ ]`>"
+}
 ```
 
-Add testing tasks at the end of task.md:
-```
-## Testing (added before moving to Testing)
+`task_write` overwrites the whole file, so include the existing implementation phases in your `content`. (Use `read_asset { topic: "<topic>", asset_type: "task", area: "Working" }` first to get the current content.)
 
-- [ ] **T1** [Test the implementation]
-- [ ] **T2** [Verify it works as expected]
+### 6. Mark the topic complete and push to Testing
+
+```
+task_status  { topic: "<topic>", area: "Working", status: "complete" }
+topics_push  { topic: "<topic>", area: "Testing" }
 ```
 
-**This is the ONLY place for testing tasks - they are added AFTER development is complete, right before moving to Testing.**
-
-### Step 8: Push to Testing
-When done with testing tasks added, push to Testing - queue.md is automatically deleted:
-```
-topics_push {topic: "<topic-name>", area: "Testing"}
-```
+The mode config deletes `queue.md` when entering Testing — that's intentional.
 
 ---
 
-## Key Rules
+## File placement
 
-0. **CREATE /src FIRST** - Before any code
+```
+<project-root>/
+├── src/                    # all source code lives here
+└── spec/
+    ├── Staging/
+    │   ├── queue.md
+    │   └── <topic>/
+    │       ├── topic.md
+    │       ├── <topic>_spec.md
+    │       └── <topic>_task.md
+    └── Working/
+        └── <topic>/
+            ├── topic.md
+            ├── <topic>_spec.md
+            └── <topic>_task.md
+```
 
-1. **MUST be in queue** - Topic must be listed in area queue.md to be pushable
-
-2. **ALL code in /src** - At project root, never in topic directories
-
-3. **Link every file** - Use index_add
-
-4. **CHECK OFF TASKS RELIGIOUSLY** - After completing each task, mark it complete with `- [x]`. NEVER skip this!
-
-5. **Add testing tasks last** - Before pushing to Testing, add test tasks
-
-6. **Queue deleted at Testing** - Normal behavior
+For nested topics (`auth/login`), the spec/task filenames become `auth-login_spec.md` and `auth-login_task.md` inside `spec/<Area>/auth/login/`.
 
 ---
 
-## Queue File Location
+## Definition of done
 
-**The queue.md is in the AREA, not in topic folders:**
-```
-spec/
-├── Staging/
-│   └── queue.md    ← Central to-do list for Staging
-├── Working/
-│   └── queue.md    ← Central to-do list for Working
-└── ...
-```
+A topic is done with BUILD when **all** of these hold:
+
+- Every implementation task in `<topic>_task.md` is `- [x]`.
+- Every source file you wrote or substantively changed has a matching `index_add` link with `link_type: "implementation"`.
+- Decisions not in the spec are captured via `notes_add`.
+- Test tasks have been appended to the task file.
+- `task_status` is `complete`.
+- `topics_push { area: "Testing" }` succeeded.
+
+If any item above is missing, the topic is not ready for Testing.
 
 ---
 
-## Example
+## Failure modes
 
-```
-# Check if topic is in queue
-queue_check {topic: "auth", area: "Staging"}
-# If not ready, add it:
-queue_add {topic: "auth", area: "Staging"}
-
-# List what's in the queue
-queue_list {area: "Staging"}
-
-# Push to Working
-topics_push {topic: "auth", area: "Working"}
-
-# Build in Working
-# ... create files in /src ...
-# ... check off tasks ...
-
-# Add testing tasks, then push to Testing
-topics_push {topic: "auth", area: "Testing"}
-```
+- **`topics_push` rejects you in Staging** — topic isn't in `Staging/queue.md`. Run `queue_add`, then `queue_check`.
+- **`task_write` rejects you** — the spec file doesn't exist yet. The topic isn't fully created; run `spec_add` first.
+- **`tasks_complete` says "task at index N not found"** — the index is out of range. Run `tasks_list` again to see the current indices; they're recalculated each call.
+- **You wrote a file outside `src/`** — that's a smell. Either move it into `src/`, or skip `index_add` and add a project-level note via `notes_add` explaining why.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -652,14 +652,20 @@ unispec mcp /path/to/project
 
 ### MCP Tools Available
 
-When the MCP server is running, the following tools are available:
+When the MCP server is running, it exposes 31 built-in tools plus one dynamic `unispec_<name>` tool per configured connector. See [MCP Documentation](mcp.md) for the full schema of each tool.
 
-- `unispec_topic_list` - List topics in an area
-- `unispec_topic_show` - Show topic details
-- `unispec_area_list` - List all areas
-- `unispec_area_health` - Show area health
-- `unispec_index_find` - Find files linked to a topic
-- `unispec_connector_*` - Run custom connectors
+Tools the server publishes (real names, used verbatim by agents):
+
+- Areas: `areas_list`
+- Topics: `topics_list`, `topics_add`, `topics_show`, `topics_delete`, `topics_push`, `topics_pull`, `topics_progress`
+- Reading: `read_asset`, `unispec_read_spec`
+- Specs & tasks: `spec_add`, `spec_write`, `task_write`, `task_status`, `tasks_list`, `tasks_complete`, `tasks_incomplete`
+- Notes: `notes_read`, `notes_add`
+- Queue: `queue_list`, `queue_add`, `queue_remove`, `queue_check`, `queue_reorder`
+- Index: `index_add`, `index_find`, `index_lookup`, `index_list`, `index_graph`, `index_backlinks`, `unispec_bind_spec`
+- Dynamic: `unispec_<connector-name>` for each connector defined in `.agent/config.toml`
+
+CLI commands like `unispec area add`, `unispec index remove`, `unispec mode activate`, `unispec connector new`, `unispec pkg install` are **not** exposed via MCP — they're considered setup/config commands. Run them from the shell.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,21 +4,17 @@ Complete reference for UniSpec configuration files, environment variables, and s
 
 ---
 
-## Configuration Hierarchy
+## Configuration hierarchy
 
-UniSpec uses a three-level configuration hierarchy:
+UniSpec searches three levels (most specific first):
 
-```
-System (install-wide)
-    ↓
-Global (user-wide)  
-    ↓
-Local (project-specific)
-```
+1. **Local** — `./.agent/` (project-specific). First win.
+2. **Global** — `~/.config/unispec/` (user-wide).
+3. **System** — `/usr/share/unispec/` on Linux (install-wide).
 
-### Level 1: System (Install-Wide)
+Local values override global, which override system.
 
-Shared across all users on the system. Located at:
+### Level 1: System
 
 | Platform | Path |
 |----------|------|
@@ -26,92 +22,63 @@ Shared across all users on the system. Located at:
 | macOS | `/usr/local/share/unispec/` |
 | Windows | `%ProgramData%\unispec\` |
 
-Contains:
-- Default modes (e.g., `simple`)
-- Default area templates
-- System-wide workflows
+Contains default modes, area templates, and system-wide workflows.
 
-### Level 2: Global (User-Wide)
-
-Per-user configuration. Located at:
+### Level 2: Global
 
 | Platform | Path |
 |----------|------|
-| Linux | `~/.config/unispec/` |
-| macOS | `~/.config/unispec/` |
+| Linux / macOS | `~/.config/unispec/` |
 | Windows | `%APPDATA%\unispec\` |
 
-Contains:
-- Custom modes (`.agent/modes/`)
-- Custom area templates (`.agent/areas/`)
-- User preferences
+Contains user-installed modes, area templates, and preferences.
 
-### Level 3: Local (Project-Specific)
-
-Per-project configuration. Located in your project directory:
+### Level 3: Local
 
 ```
 project/
-├── .agent/           ← Project-level config
+├── .agent/
 │   ├── config.toml
+│   ├── skill.md
 │   ├── modes/
 │   └── workflows/
-└── spec/             ← Topic specs
+└── spec/
     ├── Staging/
     ├── Working/
     └── Build/
 ```
 
-Contains:
-- Project-specific config (`.agent/config.toml`)
-- Active mode (local copy)
-- Project topics
-
-### Priority
-
-When loading configurations, UniSpec searches in this order:
-1. Local (project) → 2. Global (user) → 3. System (install)
-
-This means:
-- Local configs override global configs
-- Global configs override system defaults
-- You can always customize at the project level
-
 ---
 
-## Configuration Files
+## `.agent/config.toml` (Local)
 
-### `.agent/config.toml` (Local)
-
-Main configuration file for the UniSpec agent system. Created in your project root under `.agent/config.toml`.
+Main project-level configuration. Fields below match what the CLI actually reads (`src/fs/config.rs`).
 
 ```toml
-# UniSpec Agent Configuration
+# Currently active mode (must match a directory name under .agent/modes/, ~/.config/unispec/.agent/modes/, or the system path).
+current_mode = "default"
 
-# Current active mode (default: "simple")
-current_mode = "simple"
+# Default area for tools that accept an optional `area` argument.
+area = "Staging"
 
-# Default area for topic operations
-default_area = "Working"
+# Areas that refuse area_remove / destructive operations.
+protected_areas = []
 
-# Protected areas that cannot be deleted
-protected_areas = ["Staging", "Working", "Build"]
+# Show the platypus mascot in the TUI.
+paddy_enabled = false
 
-# Enable/disable platypus mascot
-paddy_enabled = true
-
-# Ingest Configuration - How code is analyzed and stored
+# Ingest configuration — how `unispec ingest run` parses and stores code analysis.
 [ingest]
-auto_index = true              # Automatically add to index when ingesting
-index_on_complete = false       # Index when topic is marked complete (future)
-capture_functions = true       # Extract functions from code
-capture_structs = true         # Extract structs from code
-capture_enums = true           # Extract enums from code
-capture_imports = true         # Extract imports from code
-output_format = "toml"         # Output format: "toml", "md", or "both"
-languages = []                 # Languages to parse (empty = all: rust, javascript, typescript, python, go, bash)
+auto_index = false                # Auto-add ingested files to the index
+index_on_complete = false         # Re-index when a topic is marked complete
+capture_functions = true
+capture_structs = true
+capture_enums = true
+capture_imports = true
+output_format = "toml"            # "toml" | "md" | "both"
+languages = []                    # Empty = all supported: rust, javascript, typescript, python, go, bash
 
-# Connectors - Custom commands that become MCP tools
+# Connectors — shell commands exposed as MCP tools (unispec_<name>).
 [[connector]]
 name = "test"
 description = "Run test suite"
@@ -122,191 +89,126 @@ working_dir = "/project/root"
 timeout = 120
 ```
 
-### Configuration Options
+### Field reference
 
-| Option | Type | Description | Default |
-|--------|------|-------------|---------|
-| `current_mode` | string | Active agent mode | `"simple"` |
-| `default_area` | string | Default area for operations | `"Working"` |
-| `protected_areas` | array | Areas that cannot be deleted | `["Staging", "Working", "Build"]` |
-| `paddy_enabled` | boolean | Show platypus mascot in TUI | `true` |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `current_mode` | string | `"default"` | Active mode (directory under `.agent/modes/`). |
+| `area` | string | `"Staging"` | Default area used when a tool omits `area`. |
+| `protected_areas` | array<string> | `[]` | Areas protected from deletion. |
+| `paddy_enabled` | bool | `false` | Show the platypus mascot in the TUI. |
 
-### Ingest Configuration Options
+### `[ingest]`
 
-| Option | Type | Description | Default |
-|--------|------|-------------|---------|
-| `ingest.auto_index` | boolean | Auto-add to index.toml on ingest | `false` |
-| `ingest.index_on_complete` | boolean | Index when topic marked complete | `false` |
-| `ingest.capture_functions` | boolean | Extract functions | `true` |
-| `ingest.capture_structs` | boolean | Extract structs | `true` |
-| `ingest.capture_enums` | boolean | Extract enums | `true` |
-| `ingest.capture_imports` | boolean | Extract imports | `true` |
-| `ingest.output_format` | string | Storage format: "toml", "md", "both" | `"toml"` |
-| `ingest.languages` | array | Specific languages to parse | `[]` (all) |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auto_index` | bool | `false` | Add ingested files to the link index. |
+| `index_on_complete` | bool | `false` | Re-index when a topic completes. |
+| `capture_functions` | bool | `true` | Extract function declarations. |
+| `capture_structs` | bool | `true` | Extract struct/class declarations. |
+| `capture_enums` | bool | `true` | Extract enums. |
+| `capture_imports` | bool | `true` | Extract imports/use statements. |
+| `output_format` | string | `"toml"` | `"toml"` writes `spec/code_analysis.toml`; `"md"` writes per-file markdown; `"both"` writes both. |
+| `languages` | array<string> | `[]` | Restrict parsing to these languages. Empty = all supported. |
 
-### Supported Languages for Ingest
+### `[[connector]]`
 
-| Language | Extensions | Grammar |
-|----------|------------|---------|
-| Rust | `.rs` | tree-sitter-rust |
-| JavaScript | `.js`, `.jsx` | tree-sitter-javascript |
-| TypeScript | `.ts`, `.tsx` | tree-sitter-typescript |
-| Python | `.py` | tree-sitter-python |
-| Go | `.go` | tree-sitter-go |
-| Bash | `.sh`, `.bash` | tree-sitter-bash |
+Each connector becomes an MCP tool named `unispec_<name>` automatically.
 
-### Connector Configuration
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Lowercase, underscores only. |
+| `description` | string | Shown in `connector_list` output. |
+| `command` | string | Executable to run. |
+| `args` | array<string> | Default args, prepended before any extra args. |
+| `env` | table | Environment variables. |
+| `working_dir` | string | Working directory. |
+| `timeout` | integer | Timeout in seconds. |
 
-Each connector in the config file:
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `name` | string | Connector identifier (lowercase, underscores only) |
-| `description` | string | Human-readable description |
-| `command` | string | Shell command to execute |
-| `args` | array | Command arguments |
-| `env` | table | Environment variables |
-| `working_dir` | string | Working directory for command |
-| `timeout` | integer | Timeout in seconds |
+Supported parser languages: `rust`, `javascript`, `typescript`, `python`, `go`, `bash`.
 
 ---
 
-## Global Modes
+## Modes
 
-Modes can be installed at the global level to be available across all projects.
+See [modes.md](modes.md) for the full mode reference. A mode is a directory under `.agent/modes/<name>/` containing `mode.toml`, `skill.md`, optional `workflows/`, `areas/`, and `templates/`.
 
-### Global Mode Directory
-
-```
-~/.config/unispec/
-└── .agent/
-    └── modes/
-        ├── simple/
-        ├── sprint/
-        └── custom-mode/
-```
-
-### Installing Modes Globally
-
-Use `--global` flag when adding modes:
-
-```bash
-# Add a mode to global (user-wide) storage
-unispec mode add /path/to/mymode --global
-
-# Remove a global mode
-unispec mode remove mymode --global
-```
-
-### Mode Search Order
-
-When you run `unispec mode list` or `unispec mode activate`, modes are searched:
-
+Mode search order:
 1. Local: `./.agent/modes/`
 2. Global: `~/.config/unispec/.agent/modes/`
 3. System: `/usr/share/unispec/.agent/modes/`
 
-The first match wins.
+First match wins.
 
 ---
 
-## Area Files
+## Area files
 
-Each area has an `area.md` file in `spec/<area>/area.md`.
-
-### Local Areas
-
-```
-spec/
-├── Staging/
-│   └── area.md
-├── Working/
-│   └── area.md
-└── Build/
-    └── area.md
-```
-
-### Global Area Templates
-
-```
-~/.config/unispec/
-└── .agent/
-    └── areas/
-        ├── staging/
-        │   └── area.md
-        ├── working/
-        │   └── area.md
-        └── custom/
-            └── area.md
-```
-
-When you create a new area with `unispec area add`, UniSpec checks:
-1. Local `.agent/areas/<name>/area.md`
-2. Global `.agent/areas/<name>/area.md`
-3. System `/usr/share/unispec/.agent/areas/<name>/area.md`
-
-### Format
+Each area has an `area.md` file in `spec/<area>/area.md`. Format:
 
 ```markdown
-# Area: <Area Name>
+---
+area: <AreaName>
+short: <one-line description>
+---
 
-Description of this area's purpose.
+# <AreaName>
 
-## Topics
+## Purpose
+<what this area represents>
 
-- Topic A
-- Topic B
-
-## Notes
-
-Additional notes about this area.
+## Guidelines
+- <what belongs here>
+- <what does not>
 ```
+
+Area templates are stored under `.agent/modes/<mode>/areas/<area>/area.md`. `unispec init` and `unispec area add` copy these into `spec/<area>/area.md` when creating areas.
 
 ---
 
-## MCP Configuration
+## Connector MCP configuration
 
-Generated automatically from connectors to `.agent/mcp.json`:
+`unispec connector mcp` generates a `mcpServers` block you can drop into an editor's settings:
 
 ```json
 {
   "mcpServers": {
     "unispec_test": {
       "command": "unispec",
-      "args": ["connector", "run", "test"],
-      "env": null
+      "args": ["connector", "run", "test"]
     }
   }
 }
 ```
 
----
-
-## Environment Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `UNISPEC_ROOT` | Override project root directory | Auto-detected |
-| `UNISPEC_CONFIG` | Custom config file path | `.agent/config.toml` |
-| `UNISPEC_MCP_PORT` | MCP server port | `3000` |
+Most users instead use a single `unispec mcp` server that exposes both the static UniSpec tools and the dynamic `unispec_<name>` connector tools. See [mcp.md](mcp.md) for the standard setup.
 
 ---
 
-## Exit Codes
+## Environment variables
 
-| Code | Description |
-|------|-------------|
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `UNISPEC_ROOT` | Override project root directory. | Auto-detected from current dir. |
+| `UNISPEC_MODE` | Override active mode for this session. | Value of `current_mode`. |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
 | 0 | Success |
 | 1 | General error |
 | 2 | Invalid arguments |
 | 3 | Project not initialized |
-| 4 | Topic/area not found |
+| 4 | Topic or area not found |
 
 ---
 
-## See Also
+## See also
 
-- [Commands Reference](commands.md) - CLI command documentation
-- [Modes Documentation](modes.md) - Custom workflow configurations
-- [MCP Documentation](mcp.md) - AI agent integration
-- [Getting Started](getting-started.md) - Quick start guide
+- [Commands Reference](commands.md)
+- [Modes](modes.md)
+- [MCP Integration](mcp.md)
+- [Getting Started](getting-started.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,36 +1,36 @@
 # Getting Started with UniSpec
 
-UniSpec is a tool that helps you build better software by organizing your work around specifications (specs). Instead of jumping straight into code, you define what you're building first, then track your progress as you implement it.
+UniSpec is a spec-driven workflow tool. You write a spec for each feature, then move it through a fixed pipeline of areas (default: `Staging → Working → Testing → Fixing → Build`). Code is linked back to specs, so AI agents and humans both know exactly what's being built and why.
 
-This guide walks you through the basics.
+This guide walks through the basics.
 
 ---
 
 ## What is UniSpec?
 
-Think of UniSpec as a task manager that revolves around **specs** instead of generic todos. Each feature or project gets a spec that describes:
+For each feature, you produce three files under `spec/<Area>/<topic>/`:
 
-- **What** you're building (requirements)
-- **Why** you're building it (problem statement)
-- **How** you'll know it's done (acceptance criteria)
-- **What** tasks need to be done
+| File | Purpose |
+|------|---------|
+| `topic.md` | What this topic is — short description, sub-topics, notes. |
+| `<topic>_spec.md` | **What** you're building: requirements, examples, data model. |
+| `<topic>_task.md` | The implementation tasks, each tracked with `- [ ]` / `- [x]`. |
 
-Your specs move through **areas** (like Staging → Working → Build) as you progress from planning to implementation to done.
+UniSpec's MCP server exposes tools that an AI agent (Claude, Cursor, Windsurf, Cline, etc.) calls directly — so the agent can create topics, write specs, flip checkboxes, and link code without you copy-pasting commands.
 
 ---
 
 ## Installation
 
-### Quick Install
-
 ```bash
-# Linux/macOS (using Cargo)
+# Linux / macOS (Cargo)
 cargo install unispec
 
-# Or download a release from GitHub
+# Arch Linux (AUR)
+yay -S unispec
 ```
 
-### Verify It Works
+Verify:
 
 ```bash
 unispec --version
@@ -38,359 +38,184 @@ unispec --version
 
 ---
 
-## Your First Project
+## First project
 
-### Step 1: Create a Project Directory
+### 1. Initialize
 
 ```bash
 mkdir my-first-project
 cd my-first-project
-```
-
-### Step 2: Initialize UniSpec
-
-```bash
 unispec init
 ```
 
-This creates the basic structure:
+This creates:
 
 ```
-my-project/
-├── spec/              # Your specs live here
-│   ├── Staging/       # New specs start here
-│   ├── Working/       # Specs you're actively working on
-│   └── Build/         # Completed specs ready to deploy
-└── .agent/            # UniSpec configuration
+my-first-project/
+├── spec/
+│   ├── Staging/area.md
+│   ├── Working/area.md
+│   ├── Testing/area.md
+│   ├── Fixing/area.md
+│   └── Build/area.md
+└── .agent/
+    ├── config.toml
+    ├── skill.md
+    ├── modes/default/
+    └── workflows/
 ```
 
-### Step 3: Launch the Interactive Interface
+The areas come from the default mode (`.agent/modes/default/mode.toml`).
+
+### 2. Launch the TUI
 
 ```bash
 unispec
 ```
 
-This opens the **TUI** (Terminal User Interface) - a visual way to navigate your specs. You'll see:
+Areas appear on the left; topics show up inside each area once you create them. The platypus mascot is off by default — toggle with `\`.
 
-- Areas on the left (Staging, Working, Build)
-- Topics in each area
-- Paddy the platypus (toggle with `\`)
+### 3. Create a topic
 
-### Step 4: Create Your First Topic
+In the TUI:
+1. `↓` to highlight `Staging`, `→` to enter.
+2. `n` to create a topic.
+3. Type a name (kebab-case recommended, e.g., `user-login`).
+4. `Enter`.
 
-With the TUI open:
-
-1. Press `↓` to select "Staging"
-2. Press `→` to enter Staging
-3. Press `n` to create a new topic
-4. Type a name like "User Login"
-5. Press `Enter`
-
-Now you've created a topic!
+That creates `spec/Staging/user-login/topic.md`. The spec file (`user-login_spec.md`) and task file (`user-login_task.md`) are written when you (or your agent) run `spec_add` through the MCP server.
 
 ---
 
-## Understanding Topics
+## File layout the tools create
 
-A **topic** is a unit of work - a feature, bug fix, or project. Each topic contains:
-
-### `spec.md` - The Specification
-
-This describes **what** you're building. Here's a simple template:
-
-```markdown
-# Feature Name
-
-## Problem Statement
-What problem does this solve?
-
-## User Stories
-- As a [user], I want [action] so that [benefit]
-
-## Requirements
-- [ ] Must have feature
-- [ ] Another must have
-
-## Acceptance Criteria
-1. Criterion 1
-2. Criterion 2
+```
+spec/
+└── <Area>/
+    └── <topic>/
+        ├── topic.md
+        ├── <topic>_spec.md      # slashes/spaces in <topic> become '-'
+        └── <topic>_task.md
 ```
 
-### `tasks.md` - The Tasks
-
-This lists the work to be done:
-
-```markdown
-# Tasks - Feature Name
-
-## Implementation
-- [ ] Task 1
-- [ ] Task 2
-
-## Testing  
-- [ ] Test 1
-- [ ] Test 2
-```
+For a nested topic `auth/login`, the files are `auth-login_spec.md` and `auth-login_task.md` inside `spec/<Area>/auth/login/`.
 
 ---
 
-## The Basic Workflow
+## The pipeline
 
-### 1. Create a Spec in Staging
+| Area | Stage |
+|------|-------|
+| Staging | Writing the spec. |
+| Working | Implementing code in `src/`. |
+| Testing | Running build/test pipelines. |
+| Fixing | Repairing issues found in Testing. |
+| Build | Done. Treated as immutable. |
 
-Start by creating a topic in Staging. This is where new ideas go before they're ready for work.
-
-### 2. Move to Working When Ready
-
-When you've written your spec and it's ready to implement:
+To move a topic between areas:
 
 ```bash
-# From command line
-unispec topic push "Your Topic" Working
+unispec topic push <topic> <target-area>
 ```
 
-Or in the TUI:
-- Select your topic
-- Press `p`
-- Type "Working"
+Or in the TUI, select the topic and press `p`.
 
-### 3. Implement and Track Progress
-
-Now you're in Working! This is where you:
-- Write code
-- Check off tasks as you complete them
-- Update the spec if requirements change
-
-### 4. Move to Build When Done
-
-When everything is implemented and tested:
-
-```bash
-unispec topic push "Your Topic" Build
-```
-
-Build is for completed work - ready to deploy or ship.
-
-### 5. Done!
-
-Your spec has moved through the full workflow: Staging → Working → Build
+`Staging` and `Fixing` require the topic to be listed in `spec/<area>/queue.md` before push (the "readiness queue"). The CLI doesn't have a direct command for that yet — your agent or the MCP `queue_add` tool handles it.
 
 ---
 
-## Using the TUI
-
-The TUI is your primary interface. Here's what you need to know:
-
-### Navigation
+## TUI cheatsheet
 
 | Key | Action |
 |-----|--------|
-| `↑` / `↓` | Move between topics/areas |
-| `→` | Enter selected area or topic |
+| `↑` / `↓` | Move between items |
+| `→` | Enter an area or topic |
 | `←` | Go back |
-| `Enter` | Open a topic file |
-
-### Actions
-
-| Key | Action |
-|-----|--------|
+| `Enter` | Open the highlighted file in your default editor |
 | `n` | Create new topic |
-| `r` | Remove topic (with confirmation) |
+| `r` | Remove topic (confirm) |
 | `p` | Push topic to another area |
 | `f` | Find files linked to this topic |
-| `\` | Toggle Paddy the platypus |
+| `/` | Search/filter |
+| `\` | Toggle the platypus mascot |
 | `q` | Quit |
 
-### Tips
-
-- Press `/` to search/filter topics
-- Your specs are just regular Markdown files - you can edit them in your favorite editor too
-- Use `unispec topic list` to see all topics from the command line
+Your specs are plain Markdown — open them in any editor. `unispec topic list` works from the command line too.
 
 ---
 
-## Quick Command Reference
+## Quick CLI reference
 
 ```bash
-# Start the TUI
-unispec
-
-# Initialize a new project
-unispec init
-
-# Create a topic
-unispec topic add "Feature Name"
-
-# List topics
-unispec topic list
-
-# Show progress
-unispec topic progress
-
-# Move a topic to another area
-unispec topic push "Feature Name" Working
-
-# List areas
+unispec                      # launch TUI
+unispec init                 # initialize project
+unispec topic add "Feature"  # create a topic in the default area (Staging)
+unispec topic list           # list topics in the default area
+unispec topic progress       # task progress per area
+unispec topic push <name> <area>
 unispec area list
-
-# Show area health
 unispec area health
+unispec index add --topic <name> --path <path>
+unispec mode list
+unispec mode activate <mode>
+unispec mcp                  # start the MCP server (for agents)
 ```
 
----
-
-## Why Bother with Specs?
-
-You might be thinking "this seems like extra work". Here's why it matters:
-
-1. **Clarity** - Writing down what you're building forces you to think it through
-2. **Communication** - Specs make it easy to share what you're working on
-3. **Tracking** - You always know what stage each feature is in
-4. **Completion** - Acceptance criteria make it clear when you're actually done
+For the complete CLI surface, see [commands.md](commands.md).
 
 ---
 
-## What's Next?
+## Connecting an AI agent
 
-If you just want to use UniSpec, you now know enough! The basic workflow is:
-
-1. `unispec init` - Start a project
-2. `unispec` - Open the TUI
-3. Create topics → Write specs → Implement → Move through areas
-
-But UniSpec can do much more. Read on for advanced features...
-
----
-
-## Advanced Features
-
-### Installing Modes from the Repository
-
-UniSpec has a package repository with pre-built modes for different workflows:
+UniSpec speaks MCP. To let an agent drive the pipeline:
 
 ```bash
-# See what's available
-unispec pkg list
-
-# Search for something specific
-unispec pkg search sprint
-
-# Install a mode
-unispec pkg install sprint-mode
-
-# Install globally (available to all your projects)
-unispec pkg install sprint-mode --global
+unispec init --cursor --cline --windsurf --claude_code
 ```
 
-Different modes give you different area structures. For example:
-- **Simple Mode** - Staging → Working → Build
-- **Sprint Mode** - Backlog → In Sprint → Review → Done
-- **Kanban Mode** - To Do → In Progress → Done
+Drops workflow files into the right editor folders. Or wire the MCP server directly:
 
-### Creating Custom Modes
-
-You can create your own mode with custom areas and workflows:
-
-```bash
-# Create mode directory structure
-mkdir -p .agent/modes/my-mode
+```json
+{
+  "mcpServers": {
+    "unispec": {
+      "command": "unispec",
+      "args": ["mcp"],
+      "cwd": "/abs/path/to/project"
+    }
+  }
+}
 ```
 
-Then add:
-- `mode.toml` - Mode metadata
-- `skill.md` - How AI agents should behave
-- `workflows/` - Step-by-step guides
-- `areas/` - Your custom areas
-
-See [Creating Modes](modes.md) for the full guide.
-
-### Connecting AI Editors
-
-Want AI assistants like Claude, Cursor, or Windsurf to understand your specs?
-
-```bash
-# Add editor integrations
-unispec init --cursor --cline --windsurf --claude-code
-```
-
-This creates workflow files in your editor's config folder. Now your AI can:
-- Read your specs
-- See what tasks need doing
-- Run your connectors
-
-See [MCP Integration](mcp.md) for details.
-
-### Using Connectors
-
-Connectors are custom commands that become MCP tools. Define them in `.agent/config.toml`:
-
-```toml
-[[connector]]
-name = "test"
-description = "Run the test suite"
-command = "pytest"
-args = ["tests/", "-v"]
-```
-
-Now AI can run "run the tests" and it'll execute your test command.
-
-### Indexing Code to Specs
-
-Link your code files to topics so AI knows which code implements which feature:
-
-```bash
-# Link a file to a topic
-unispec index add --topic "user-login" --path src/auth/login.rs
-
-# Find what's linked
-unispec index find "user-login" --by topic
-```
-
-See [Indexing](indexing.md) for patterns and best practices.
-
-### Configuring Your Setup
-
-UniSpec uses a three-level config hierarchy:
-
-1. **Local** - `./.agent/config.toml` (project-specific)
-2. **Global** - `~/.config/unispec/` (user-wide)
-3. **System** - `/usr/share/unispec/` (install-wide)
-
-Local overrides global, which overrides system.
-
-See [Configuration Reference](configuration.md) for all options.
+See [mcp.md](mcp.md) for the full MCP tool surface and per-editor configs.
 
 ---
 
-## Summary
+## Indexing code to specs
 
-You now know how to:
+When an agent (or you) writes a code file, link it to a topic so the spec ↔ code relationship is preserved:
 
-**Beginner:**
-- Initialize a project
-- Create and manage topics
-- Write specs and tasks
-- Move topics through areas (Staging → Working → Build)
-- Use the TUI
+```bash
+unispec index add --topic user-login --path src/auth/login.rs \
+  --link_type implementation \
+  --tags "auth,backend" \
+  --annotation "Core login handler"
+```
 
-**Advanced:**
-- Install modes from the repository
-- Create custom modes
-- Connect AI editors
-- Use connectors
-- Index code to specs
-- Configure your setup
+The link is stored in `spec/index.toml`. Agents can query it with `index_find`, `index_list`, `index_backlinks`, and `index_graph`.
+
+See [indexing.md](indexing.md) for the full feature set.
 
 ---
 
-## Learn More
+## What's next?
 
-- [Commands Reference](commands.md) - Complete CLI documentation
-- [Configuration Reference](configuration.md) - Config files and settings
-- [Creating Modes](modes.md) - Build custom workflows
-- [MCP Integration](mcp.md) - Connect AI agents
-- [Indexing](indexing.md) - Link code to specs
+- [Commands Reference](commands.md) — all CLI commands and flags
+- [MCP Integration](mcp.md) — every MCP tool the server exposes
+- [Modes](modes.md) — customize the pipeline (areas, templates, workflows)
+- [Configuration](configuration.md) — `.agent/config.toml`, env vars, exit codes
+- [Indexing](indexing.md) — link code to specs
 
 ---
 
-*Write the spec first. Code second. Paddy believes in you.* 🦫
+*Write the spec first. Code second.*

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -1,314 +1,205 @@
 # Indexing
 
-Indexing links your specs to your code. When you index a file to a topic, AI agents can find the relevant code when working on that spec. The index now supports tags, annotations, exports (capability registry), and provides graph visualization and backlinks.
+The index links each topic to one or more code files (or directories). Once linked, AI agents can find which code implements which spec without re-reading whole files.
 
-## Why Index?
+Indexing supports tags, annotations, exports (capability registry), graph visualization, and backlinks.
+
+## Why index?
 
 Without indexing:
-- AI doesn't know which code implements which feature
-- You have to explain context every time
-- Code-to-spec connections are lost
-- Agent A reading Agent B's code must read entire files to find what it needs
+- An agent must read every file to figure out which spec it implements.
+- Code-to-spec connections are lost when files move or split.
+- Agents on different topics can't tell what each other's topic exposes.
 
 With indexing:
-- AI sees "this file is for the user-login feature"
-- Automatic context when reading specs
-- Traceability from code to requirements
-- Searchable by tags and annotations
-- **Queryable exports** - find just what functions/types are available without reading all the code
+- `index_find { query: "user-login", by: "topic" }` returns every linked file in one call.
+- `index_backlinks { topic: "user-login" }` lists every topic that depends on `user-login`.
+- `index_exports` (CLI) lists the public surface a topic provides — agents query exports instead of reading entire files.
 
-## The Problem Without Exports
+## MCP vs CLI
 
-```
-Agent A on "checkout-flow" needs auth from Agent B's "user-login"
-- Must read ALL of login.rs to find usable functions (500+ lines)
-- Wasted context - just needs 3 functions
-```
+Indexing has both an MCP surface and a CLI surface. The MCP server publishes a subset.
 
-## The Solution: Exports / Capability Registry
+### MCP tools (callable by agents)
 
-Now index declares what's available from each file:
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `index_add` | `topic, path` (`area?`, `link_type?`, `tags?`, `annotation?`) | Add a link. |
+| `index_find` | `query` (`by?`) | Search by `topic` (default), `path`, or `tag`. |
+| `index_lookup` | `id` | Find an export by full `topic:name` ID. |
+| `index_list` | — (`topic?`, `path?`, `tag?`) | List all links with optional filters. |
+| `index_graph` | — | Export the link graph as JSON for visualization. |
+| `index_backlinks` | `topic` | Markdown block of files linked to the topic. |
+| `unispec_bind_spec` | `spec_path, file_path, topic` (`area?`) | Bind a code file to a spec record. |
 
-```
-user-login → src/auth/login.rs exports:
-  - user-login:login_user (function) - "Authenticate and create session"
-  - user-login:validate_token (function) - "Verify JWT token"  
-  - user-login:logout (function) - "Clear user session"
-```
+### CLI-only (not in MCP)
 
-Agent A can now:
-1. Query: "what does user-login export?"
-2. Get: Just the 3 functions with descriptions
-3. Use: `from auth import login_user  # ref:index:user-login:login_user`
-4. Backlink auto-created: checkout-flow depends on user-login
+These exist as `unispec index <sub>` but are not exposed as MCP tools. Use the host shell.
 
-## Basic Usage
+| CLI | Description |
+|-----|-------------|
+| `unispec index remove` | Remove a single link. |
+| `unispec index cleanup` | Remove links to non-existent topics or paths. |
+| `unispec index tags` | List all unique tags. |
+| `unispec index exports` | List exports (functions, classes, …) for a topic. |
+| `unispec index query` | Query exports by name/type/description/id. |
+| `unispec index depends` | Find topics that depend on a given topic. |
+| `unispec index callers` | Find references to a symbol. |
+| `unispec index full` | Show overall index statistics. |
+| `unispec index watch` | File-system watcher; updates links on file changes. |
 
-### Add a Link
+If you want any of those from an agent, shell out to the CLI.
+
+## Basic usage
+
+### Add a link
 
 ```bash
-# Link a file to a topic (basic)
-unispec index add --topic "user-login" --path src/auth/login.rs
+# Link a file
+unispec index add --topic user-login --path src/auth/login.rs
 
 # Link a directory
-unispec index add --topic "user-login" --path src/auth/
+unispec index add --topic user-login --path src/auth/
 
-# Link with tags
-unispec index add --topic "user-login" --path src/auth/login.rs --tags "auth,backend,security"
+# With tags
+unispec index add --topic user-login --path src/auth/login.rs --tags auth,backend,security
 
-# Link with an annotation
-unispec index add --topic "user-login" --path src/auth/login.rs --annotation "Core login logic, handles password verification"
+# With an annotation
+unispec index add --topic user-login --path src/auth/login.rs \
+  --annotation "Core login logic — password verification"
 ```
 
-### List Links
+From MCP:
+```json
+{
+  "name": "index_add",
+  "arguments": {
+    "topic": "user-login",
+    "path": "src/auth/login.rs",
+    "link_type": "implementation",
+    "tags": "auth,backend,security",
+    "annotation": "Core login logic — password verification"
+  }
+}
+```
+
+### List links
 
 ```bash
-# All links
-unispec index list
-
-# Links for a topic
-unispec index list --topic "user-login"
-
-# Links for a file
+unispec index list                                # all
+unispec index list --topic user-login
 unispec index list --path src/auth/login.rs
-
-# Links with a specific tag
 unispec index list --tag backend
 ```
 
-### Find Links
-
-```bash
-# Find by topic name
-unispec index find "user-login" --by topic
-
-# Find by file path
-unispec index find "login.rs" --by path
-
-# Find by tag
-unispec index find "security" --by tag
-
-# Find by annotation text
-unispec index find "password" --by annotation
+From MCP:
+```json
+{ "name": "index_list", "arguments": { "topic": "user-login" } }
 ```
 
-### Remove a Link
+### Find by topic / path / tag
 
 ```bash
-unispec index remove --topic "user-login" --path src/auth/login.rs
+unispec index find user-login --by topic
+unispec index find login.rs --by path
+unispec index find security --by tag
+unispec index find password --by annotation     # CLI supports annotation too
 ```
 
-## Enhanced Index Format
+From MCP — `by` is `"topic"` (default), `"path"`, or `"tag"`. Annotation search is CLI-only.
 
-The index now stores rich metadata:
+### Remove (CLI only)
+
+```bash
+unispec index remove --topic user-login --path src/auth/login.rs
+```
+
+## Link record format
+
+Each link is stored in `spec/index.toml`:
 
 ```toml
 [[links]]
 topic = "user-login"
 area = "Working"
 path = "src/auth/login.rs"
-type = "file"
+type = "file"             # or "directory"
 added = "2026-03-26T10:00:00Z"
 tags = ["auth", "backend", "security"]
 annotation = "Core login logic"
 ```
 
-### Fields
-
 | Field | Description |
 |-------|-------------|
-| `topic` | Topic name |
-| `area` | Area containing the topic |
-| `path` | File or directory path |
-| `type` | "file" or "directory" |
-| `added` | Timestamp when linked |
-| `tags` | List of tags for categorization |
-| `annotation` | Optional note about why linked |
-| `exports` | List of available functions/classes/etc |
+| `topic` | The topic this file implements. |
+| `area` | The area containing the topic at link time. |
+| `path` | File or directory path. |
+| `type` | `"file"` or `"directory"` (auto-detected). |
+| `added` | Timestamp. |
+| `tags` | Categorization. |
+| `annotation` | Free-form note about why this file is linked. |
+| `exports` | Optional: declared public surface of the file (see below). |
 
-## Exports (Capability Registry)
+## Exports (capability registry, CLI only)
 
-Exports declare what's available from a linked file. This is the key feature for parallel agents - Agent A can find exactly what Agent B's topic provides without reading all the code.
+Exports declare what a file makes available to other topics. This is the central feature for cross-topic agent collaboration: an agent on `checkout-flow` can query what `user-login` exports without reading `login.rs`.
 
-### Adding Exports
+### Add a link with exports
 
 ```bash
-# Add link with exports (comma-separated names, types, descriptions)
 unispec index add \
-  --topic "user-login" \
+  --topic user-login \
   --path src/auth/login.rs \
-  --exports "login_user,logout,validate_token" \
+  --exports login_user,logout,validate_token \
   --descriptions "Authenticate user,Clear session,Verify token" \
-  --export-types "function,function,function"
-
-# With function signatures
-unispec index add \
-  --topic "user-login" \
-  --path src/auth/login.rs \
-  --exports "login_user" \
-  --descriptions "Authenticate and create session" \
-  --export-types "function" \
+  --export-types function,function,function \
   --signatures "fn login_user(email: String, pass: String) -> Result<User>"
 ```
 
-### Export Types
+`exports`, `descriptions`, `export-types`, and `signatures` are positional comma-separated lists; the Nth entry of each refers to the same export.
 
-Available types:
-- `function` - Regular functions
-- `class` - Classes or structs
-- `endpoint` - API endpoints
-- `model` - Data models/types
-- `service` - Service definitions
-- `config` - Configuration items
+Export types: `function`, `class`, `endpoint`, `model`, `service`, `config`.
 
-### Listing Exports
+### List / query exports (CLI only)
 
 ```bash
-# List all exports for a topic
 unispec index exports --topic user-login
+unispec index exports                              # all topics
 
-# Output:
-# Exports for 'user-login':
-#   login_user (function)
-#     Description: Authenticate and create session
-#     ID: user-login:login_user
-#     Signature: fn login_user(email: String, pass: String) -> Result<User>
-#
-#   logout (function)
-#     Description: Clear user session
-#     ID: user-login:logout
-#
-#   validate_token (function)
-#     Description: Verify JWT token
-#     ID: user-login:validate_token
-
-# List all exports across all topics
-unispec index exports
+unispec index query login --by name
+unispec index query function --by type
+unispec index query authenticate --by description
+unispec index query user-login --by id
 ```
 
-### Querying Exports
+### Lookup by full ID (MCP)
 
-```bash
-# Search by name
-unispec index query "login" --by name
-
-# Search by type
-unispec index query "function" --by type
-
-# Search by description
-unispec index query "authenticate" --by description
-
-# Search by ID
-unispec index query "user-login" --by id
+```json
+{ "name": "index_lookup", "arguments": { "id": "user-login:login_user" } }
 ```
 
-### Finding Dependencies (What Uses What)
+### Reference comments
 
-```bash
-# Find what topics depend on a given topic
-unispec index depends --topic user-login
-
-# Output:
-# Topics depending on 'user-login':
-#   checkout-flow
-#     - login_user (user-login:login_user)
-#     - validate_token (user-login:validate_token)
-```
-
-### Lookup by ID
-
-```bash
-# Find export by full ID
-unispec index lookup --id user-login:login_user
-
-# Output:
-# Found: user-login:login_user
-#   Name: login_user
-#   Type: function
-#   Topic: user-login
-#   Path: src/auth/login.rs
-#   Description: Authenticate and create session
-```
-
-### Reference Comments (Auto-Backlinks)
-
-When using another topic's exports in your code, include the reference:
+When one topic uses another's export, add a reference comment so dependencies are tracked:
 
 ```python
-# Python
 from auth import login_user  # ref:index:user-login:login_user
-
-# Rust
+```
+```rust
 use auth::login_user; // ref:index:user-login:login_user
-
-# TypeScript
+```
+```typescript
 import { loginUser } from './auth'; // ref:index:user-login:login_user
 ```
 
-This creates automatic backlinks - when you query `index depends --topic user-login`, it will show which other topics are using its exports.
+`unispec index depends --topic user-login` (CLI) then lists every topic that uses one of its exports.
 
-Tags allow you to categorize and filter links.
-
-### Adding Tags
-
-```bash
-# Add tags when creating a link
-unispec index add --topic "payment" --path src/payment/stripe.rs --tags "payments,stripe,backend"
-
-# Multiple tags (comma-separated)
-unispec index add --topic "user-auth" --path src/auth/ --tags "auth,security,api"
-```
-
-### Searching by Tag
-
-```bash
-# Find all links with a tag
-unispec index find "backend" --by tag
-
-# List links filtered by tag
-unispec index list --tag security
-```
-
-### Listing All Tags
-
-```bash
-# See all tags in the index
-unispec index tags
-```
-
-Output:
-```
-Tags in index:
-  backend (15 links)
-  security (8 links)
-  auth (12 links)
-  frontend (6 links)
-```
-
-## Annotations
-
-Annotations add context to links - why is this file linked?
-
-```bash
-# Add annotation when linking
-unispec index add \
-  --topic "user-login" \
-  --path src/auth/validate.rs \
-  --annotation "Contains password hashing and validation logic"
-
-# Search by annotation content
-unispec index find "password" --by annotation
-```
-
-## Graph Export
-
-Export the index as a graph JSON for visualization tools:
+## Graph export (MCP)
 
 ```bash
 unispec index graph
 ```
 
-Output:
 ```json
 {
   "nodes": [
@@ -321,206 +212,35 @@ Output:
 }
 ```
 
-This can be visualized in tools like:
-- Obsidian
-- Gephi
-- D3.js
-- Graphviz
+Feeds visualizers like Obsidian, Gephi, D3.js, or Graphviz.
 
-## Backlinks
-
-Generate a backlinks file for any topic:
+## Backlinks (MCP)
 
 ```bash
-unispec index backlinks --topic "user-login"
+unispec index backlinks --topic user-login
 ```
 
-Output:
-```
+```markdown
 # Backlinks: user-login
 
 Area: Working
 
 ## Linked Files
-
-- [src/auth/login.rs](src/auth/login.rs) - Core login logic
-- [src/auth/password.rs](src/auth/password.rs) - password handling
-- [tests/login_test.py](tests/login_test.py) - test coverage
+- [src/auth/login.rs](src/auth/login.rs) — Core login logic
+- [src/auth/password.rs](src/auth/password.rs) — password handling
+- [tests/login_test.py](tests/login_test.py) — test coverage
 
 ## Tags
-
 - auth
 - backend
 - security
 ```
 
-## MCP Tools
+## Code-analysis store (TOML)
 
-The enhanced index is available via MCP:
+`unispec ingest run <path>` parses every supported source file and writes the result to `spec/code_analysis.toml` (or per-file markdown, per `[ingest].output_format` in `.agent/config.toml`).
 
-| Tool | Description |
-|------|-------------|
-| `index_list` | List links, optionally filtered by topic, path, or tag |
-| `index_add` | Add link with tags, annotation, and exports |
-| `index_find` | Find by topic, path, tag, or annotation |
-| `index_tags` | List all unique tags |
-| `index_graph` | Export graph JSON |
-| `index_backlinks` | Generate backlinks markdown |
-| `index_exports` | List exports for a topic |
-| `index_query` | Query exports by name, type, description, or ID |
-| `index_depends` | Find what topics depend on a given topic |
-| `index_lookup` | Find export by full ID |
-
-### MCP Examples
-
-```python
-# Get exports for a topic
-{"name": "index_exports", "arguments": {"topic": "user-login"}}
-
-# Query exports by name
-{"name": "index_query", "arguments": {"query": "login", "by": "name"}}
-
-# Query exports by type
-{"name": "index_query", "arguments": {"query": "function", "by": "type"}}
-
-# Query exports by description
-{"name": "index_query", "arguments": {"query": "authenticate", "by": "description"}}
-
-# Find what depends on a topic
-{"name": "index_depends", "arguments": {"topic": "user-login"}}
-
-# Lookup by full ID
-{"name": "index_lookup", "arguments": {"id": "user-login:login_user"}}
-
-# Find links by tag
-{"name": "index_find", "arguments": {"query": "backend", "by": "tag"}}
-
-# Get graph for visualization
-{"name": "index_graph", "arguments": {}}
-
-# Get backlinks for a topic
-{"name": "index_backlinks", "arguments": {"topic": "user-login"}}
-```
-
-## Best Practices
-
-### Use Tags for Categorization
-
-```bash
-# By layer
-unispec index add --topic "api" --path api/ --tags "backend,api,rest"
-
-# By feature
-unispec index add --topic "api" --path api/v2/ --tags "backend,api,v2"
-
-# By status
-unispec index add --topic "api" --path api/legacy/ --tags "backend,api,deprecated"
-```
-
-### Use Annotations for Context
-
-```bash
-# Explain why this file is linked
-unispec index add \
-  --topic "payment" \
-  --path src/payment/stripe.rs \
-  --annotation "Main integration point - all payment flows go through here"
-
-# Note important details
-unispec index add \
-  --topic "auth" \
-  --path src/auth/jwt.rs \
-  --annotation "Token generation - handles refresh tokens differently on mobile vs web"
-```
-
-### Tag Conventions
-
-Establish conventions for consistency:
-
-| Prefix | Meaning |
-|--------|---------|
-| `backend` | Server-side code |
-| `frontend` | Client-side code |
-| `tests` | Test files |
-| `docs` | Documentation |
-| `config` | Configuration |
-| `deprecated` | Legacy code |
-
-## Index in Action
-
-### With AI Editors
-
-When you open a spec in Cursor/Claude:
-
-```
-User Login spec says:
-- Email/password login
-- Password reset
-
-Linked files (tagged: auth, backend):
-- src/auth/login.rs (Core login logic)
-- src/auth/password.rs
-- tests/login_test.py
-
-Files tagged 'security':
-- src/auth/rate_limit.rs
-- src/auth/mfa.rs
-```
-
-### With MCP
-
-```
-Find all files tagged 'security' for user-login
-→ src/auth/rate_limit.rs (rate limiting)
-→ src/auth/mfa.rs (two-factor)
-→ src/auth/session.rs (session security)
-```
-
-## Example Workflow
-
-```bash
-# 1. Create topic
-unispec topic add "Payment API" -a Staging
-
-# 2. Write spec
-# ... edit spec/Staging/payment-api/spec.md
-
-# 3. Link code with tags and annotations
-unispec index add \
-  --topic "payment-api" \
-  --path src/payment/stripe.rs \
-  --tags "payments,stripe,backend" \
-  --annotation "Main Stripe integration"
-
-unispec index add \
-  --topic "payment-api" \
-  --path src/payment/webhook.rs \
-  --tags "payments,webhook,backend" \
-  --annotation "Handles Stripe webhook events"
-
-# 4. Link tests
-unispec index add \
-  --topic "payment-api" \
-  --path tests/payment/ \
-  --tags "payments,tests"
-
-# 5. Query by tag
-unispec index find "stripe" --by tag
-
-# 6. Get graph for visualization
-unispec index graph > graph.json
-
-# 7. Generate backlinks
-unispec index backlinks --topic "payment-api"
-```
-
----
-
-## Code Analysis Store (TOML)
-
-UniSpec stores code analysis data in `spec/code_analysis.toml`. This provides a central repository for all code extracted from ingested topics.
-
-### File Structure
+### File structure
 
 ```toml
 [topics.myproject]
@@ -534,50 +254,79 @@ language = "rust"
 functions = [
   { name = "main", signature = "fn main()", start_line = 1, end_line = 10 }
 ]
-structs = [
-  { name = "Cli" }
-]
+structs = [{ name = "Cli" }]
 enums = []
 imports = ["use std::..."]
 ```
 
-### How It Works
-
-1. **During Ingest**: When you run `unispec ingest run`, tree-sitter parses all files
-2. **Configuration**: Controlled by `.agent/config.toml` `[ingest]` settings
-3. **Storage**: Saved to `spec/code_analysis.toml` (or MD files, or both)
-
 ### Configuration
 
-In `.agent/config.toml`:
+`.agent/config.toml`:
 
 ```toml
 [ingest]
-auto_index = true           # Auto-add to index.toml when ingesting
-capture_functions = true    # Extract functions
-capture_structs = true      # Extract structs
-capture_enums = true       # Extract enums
-capture_imports = true     # Extract imports
-output_format = "toml"      # "toml", "md", or "both"
-languages = []              # Specific languages (empty = all)
+auto_index = true
+capture_functions = true
+capture_structs = true
+capture_enums = true
+capture_imports = true
+output_format = "toml"           # "toml" | "md" | "both"
+languages = []                   # empty = all supported
 ```
 
-### MCP Access
+There is no MCP tool named `code_analysis` or `code_parse` — these queries are CLI-only via `unispec parse file`. If you need the data from an agent, shell out.
 
-```python
-# Query code analysis from topics
-{"name": "code_analysis", "arguments": {"topic": "myproject", "item_type": "functions"}}
+## Best practices
 
-# Parse any file on-demand
-{"name": "code_parse", "arguments": {"path": "src/main.rs", "item_type": "functions"}}
+### Tags
+
+Establish conventions so filtering is reliable:
+
+| Prefix | Meaning |
+|--------|---------|
+| `backend` | Server-side code |
+| `frontend` | Client-side code |
+| `tests` | Test files |
+| `docs` | Documentation |
+| `config` | Configuration |
+| `deprecated` | Legacy code |
+
+### Annotations
+
+Explain why the file is linked, not what it is:
+
+```bash
+unispec index add --topic payment --path src/payment/stripe.rs \
+  --annotation "Main integration point — all payment flows go through here"
+```
+
+### Workflow example
+
+```bash
+# 1. Create a topic (or use MCP topics_add)
+unispec topic add "Payment API" -a Staging
+
+# 2. Write the spec (use /spec or MCP spec_add)
+
+# 3. Link implementation files with tags + annotations
+unispec index add --topic payment-api --path src/payment/stripe.rs \
+  --tags payments,stripe,backend --annotation "Main Stripe integration"
+unispec index add --topic payment-api --path src/payment/webhook.rs \
+  --tags payments,webhook,backend --annotation "Stripe webhook handler"
+
+# 4. Link tests
+unispec index add --topic payment-api --path tests/payment/ --tags payments,tests
+
+# 5. Query
+unispec index find stripe --by tag
+unispec index backlinks --topic payment-api
+unispec index graph > graph.json
 ```
 
 ---
 
-## See Also
+## See also
 
-- [Commands Reference](commands.md) - CLI command documentation
-- [Configuration Reference](configuration.md) - Config files, environment variables
-- [MCP Documentation](mcp.md) - How AI uses indexing
-
-*See commands.md for all CLI commands, or mcp.md for how AI uses indexing.*
+- [Commands Reference](commands.md)
+- [MCP Integration](mcp.md)
+- [Configuration](configuration.md)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,208 +1,101 @@
 # MCP Integration
 
-UniSpec speaks MCP (Model Context Protocol). This means you can connect AI agents like Claude, Cursor, Windsurf, and they understand your specs, workflows, and progress.
+UniSpec ships an MCP (Model Context Protocol) server so editors like Claude, Cursor, Windsurf, Cline, and any MCP-aware client can read your specs and drive your workflow.
 
-## What is MCP?
+## What MCP lets you do
 
-MCP is a protocol that lets AI tools interact with your project. Instead of just chatting with AI, it can:
+- Inspect every area, topic, spec, and task.
+- Create and update topics, specs, and tasks through structured tool calls.
+- Move topics through the pipeline and manage the readiness queue.
+- Link source files to specs and query the index.
 
-- Read your specs
-- See your workflows
-- Run your connectors
-- Query your progress
-- Understand your project structure
-- Add your own commands & scripts
+## Available MCP tools (ground truth)
 
-## Available MCP Tools
+The MCP server publishes exactly these 31 tools (plus one dynamic tool per connector you've defined). This list is generated from `src/mcp/mod.rs::get_tools()`; if you don't see a tool here, it's not exposed via MCP.
 
-UniSpec provides **33 built-in MCP tools** plus dynamic tools for each connector you define:
+### Areas
 
-### Topic Management (7 tools)
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `areas_list` | — | List all areas. |
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `topics_list` | List all topics in an area | `unispec topic list` |
-| `topics_add` | Create a new topic | `unispec topic add` |
-| `topics_show` | Show details of a topic (supports `--from` and `--all`) | `unispec topic show` |
-| `topics_delete` | Delete a topic | `unispec topic remove` |
-| `topics_push` | Move a topic to another area (supports `--from`) | `unispec topic push` |
-| `topics_pull` | Pull a topic from another area | `unispec topic pull` |
-| `topics_progress` | Show progress across topics | `unispec topic progress` |
+### Topics
 
-### Area Management (6 tools)
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `topics_list` | — (`area?` defaults to `Staging`) | List topics in an area. |
+| `topics_add` | `topic, area, short, content` | Create topic dir + `topic.md`. `content` must be ≥ 10 chars. Server writes frontmatter; don't include `---` in your `content`. |
+| `topics_show` | `topic` (`area?`, `show_all?`, `from?`) | Show files in a topic. |
+| `topics_delete` | `topic` (`area?`, `force?`) | Delete a topic. |
+| `topics_push` | `topic, area` (`source_area?`) | Move topic to another area. Source areas listed in `[readiness]` (default: `Staging`, `Fixing`) require the topic to be in `<source>/queue.md` first. |
+| `topics_pull` | `topic, source_area` | Pull a topic into `Working`. |
+| `topics_progress` | — (`area?`) | Per-topic task counts. |
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `areas_list` | List all areas | `unispec area list` |
-| `areas_add` | Add a new area | `unispec area add` |
-| `areas_remove` | Remove an area | `unispec area remove` |
-| `areas_rename` | Rename an area | `unispec area rename` |
-| `areas_default` | Set the default area | `unispec area default` |
-| `areas_health` | Show area health statistics | `unispec area health` |
+### Asset reading
 
-### Index/Link Management (14 tools)
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `read_asset` | `topic, asset_type` (`area?`) | `asset_type ∈ {"topic", "spec", "task"}`. Use `topic: "templates"` to read templates from `.agent/modes/default/templates/`. |
+| `unispec_read_spec` | `topic` (`area?`) | Returns spec + task content together. |
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `index_list` | List all index links (optional filters) | `unispec index list` |
-| `index_add` | Add a link between topic and path | `unispec index add` |
-| `index_remove` | Remove a link between topic and path | `unispec index remove` |
-| `index_find` | Find links by topic, path, tag, or annotation | `unispec index find` |
-| `index_cleanup` | Remove links to non-existent topics/paths | `unispec index cleanup` |
-| `index_tags` | List all unique tags in the index | `unispec index tags` |
-| `index_graph` | Export index as graph JSON for visualization | `unispec index graph` |
-| `index_backlinks` | Generate backlinks markdown for a topic | `unispec index backlinks` |
-| `index_exports` | List exports (functions, classes) for a topic | `unispec index exports` |
-| `index_query` | Query exports by name, type, description, or ID | `unispec index query` |
-| `index_depends` | Find what topics depend on a given topic | `unispec index depends` |
-| `index_lookup` | Find export by full ID (e.g., user-login:login_user) | `unispec index lookup` |
+### Specs & tasks
 
-### Configuration (2 tools)
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `spec_add` | `topic, area, short, spec_content, task_content` | Creates `<topic>_spec.md` and `<topic>_task.md` (slashes/spaces in `topic` become `-`). Both content fields must be ≥ 10 chars. |
+| `spec_write` | `topic, content` (`area?`) | Overwrite an existing spec. |
+| `task_write` | `topic, content` (`area?`) | Overwrite an existing task file. **Fails** if the spec doesn't exist. |
+| `task_status` | `topic, status` (`area?`) | Update frontmatter `status:`. Allowed: `pending`, `working`, `complete`. Does not touch `- [ ]` checkboxes. |
+| `tasks_list` | `topic` (`area?`) | List task lines + checkbox state. |
+| `tasks_complete` | `topic, task_index` (`note?`, `area?`) | Flip the 0-indexed task to `[x]`. |
+| `tasks_incomplete` | `topic, task_index` (`note?`, `area?`) | Flip the 0-indexed task back to `[ ]`. |
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `config_get` | Get the current configuration | `unispec set` |
-| `config_set` | Set the default area | `unispec set area` |
+### Notes
 
-### Mode Management (4 tools)
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `notes_read` | `topic` (`area?`) | Read the notes section of `<topic>_task.md`. |
+| `notes_add` | `topic, note` (`area?`) | Append a note. |
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `mode_list` | List all available agent modes | `unispec mode list` |
-| `mode_info` | Get detailed info about a mode | `unispec mode info` |
-| `mode_activate` | Activate an agent mode | `unispec mode activate` |
-| `mode_current` | Get the current active mode | `unispec mode current` |
+### Readiness queue
 
-### Connector (1 tool + dynamic)
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `queue_list` | — (`area?`) | Show `spec/<area>/queue.md`. |
+| `queue_add` | `topic` (`position?`, `area?`) | `position: 0` = first; default last. |
+| `queue_remove` | `topic` (`area?`) | Remove topic from queue. |
+| `queue_check` | `topic` (`area?`) | Returns `ready: true|false`. |
+| `queue_reorder` | `topic, new_position` (`area?`) | Move a topic in the queue. |
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `connector_list` | List all available connectors | `unispec connector list` |
-| `connector_run` | Run a connector command | `unispec connector run` |
-| `unispec_<name>` | Dynamic tool for each connector | `unispec connector run <name>` |
+### Index (file ↔ spec linking)
 
-### Code Analysis (2 tools) - NEW
+| Tool | Required args | Description |
+|------|---------------|-------------|
+| `index_add` | `topic, path` (`area?`, `link_type?`, `tags?`, `annotation?`) | Link a file or directory to a topic. |
+| `unispec_bind_spec` | `spec_path, file_path, topic` (`area?`) | Bind a code file to a spec record. |
+| `index_find` | `query` (`by?`) | `by ∈ {"topic", "path", "tag"}`, default `"topic"`. |
+| `index_lookup` | `id` | `id` is `topic:name`. |
+| `index_list` | — (`topic?`, `path?`, `tag?`) | List all links with optional filters. |
+| `index_graph` | — | Export the link graph as JSON. |
+| `index_backlinks` | `topic` | Backlinks markdown block for a topic. |
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `code_analysis` | Query code analysis data from ingested topics | `unispec ingest run` + TOML |
-| `code_parse` | Parse any file on-demand using tree-sitter | `unispec parse file` |
+## Tools NOT exposed via MCP
 
-These tools allow the AI agent to:
-- **Query indexed code**: Get functions, structs, enums from topics stored in `spec/code_analysis.toml`
-- **Parse on-demand**: Extract code elements from any file while debugging or investigating
+These commands exist in the CLI but are intentionally not in the MCP surface. Calling them as MCP tool names will fail.
 
-**Example usage:**
-```json
-// code_analysis - query indexed topics
-{ "topic": "myproject", "area": "Ingested", "item_type": "functions" }
+- Area mutation: `areas_add`, `areas_remove`, `areas_rename`, `areas_default`, `areas_health` (use `unispec area …` from the shell).
+- Index mutation/inspection: `index_remove`, `index_cleanup`, `index_tags`, `index_exports`, `index_query`, `index_depends`, `index_callers`, `index_full`, `index_watch`.
+- Config: `config_get`, `config_set`.
+- Mode: `mode_list`, `mode_info`, `mode_activate`, `mode_current`.
+- Connector management: `connector_list`, `connector_run` (each named connector is, however, exposed dynamically as `unispec_<name>` — see below).
+- Ingest/parse: `code_analysis`, `code_parse` (use `unispec ingest run` / `unispec parse file`).
+- Setup: `unispec init`, `unispec pkg …`, `unispec mode add|remove`, `unispec connector new|delete|edit`, `unispec patty …`.
 
-// code_parse - parse any file
-{ "path": "src/main.rs", "item_type": "functions", "pattern": "handle_" }
-```
+If you need to drive these from an agent, shell out to the CLI.
 
-### Configuration (2 tools)
+## Dynamic connector tools
 
-| MCP Tool | Description | CLI Equivalent |
-|----------|-------------|----------------|
-| `config_get` | Get current configuration | Internal |
-| `config_set` | Set the default area | `unispec set` |
-
----
-
-### Using MCP Tools in Conversation
-
-Once your AI is connected, you can use natural language:
-
-```
-# Topics
-"List all topics in Staging"
-"Create a new topic called 'Payment API' in Working"
-"Show me the details for the User Login topic"
-"Show the User Login topic from the Staging area"
-"Show all files for User Login across all areas"
-"Push 'Payment API' to Build"
-
-# Areas
-"What areas do we have?"
-"Add a new area called 'Review'"
-"What's the health of each area?"
-
-# Index
-"What files are linked to the authentication topic?"
-"Link src/auth/login.rs to the User Login topic"
-"Find all files linked to the payment topic"
-
-# Modes
-"Switch to sprint mode"
-"What modes are available?"
-
-# Connectors
-"Run the test connector"
-"Run lint with extra arguments"
-```
-
-### MCP Tool Parameters
-
-The `topics_show` tool supports additional parameters for multi-area topics:
-
-```json
-{
-  "topics_show": {
-    "topic": "user-auth",
-    "show_all": false,
-    "from": "Staging"
-  }
-}
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `topic` | string | Name of the topic to show (required) |
-| `show_all` | boolean | Show files from all areas (default: false) |
-| `from` | string | Show files from a specific area (e.g., "Staging", "Working") |
-
-The `topics_push` tool supports the `--from` parameter:
-
-```json
-{
-  "topics_push": {
-    "topic": "user-auth",
-    "area": "Working",
-    "source_area": "Staging"
-  }
-}
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `topic` | string | Name of the topic to push (required) |
-| `area` | string | Target area to push to (required) |
-| `source_area` | string | Source area (optional, auto-detected if not provided) |
-
-## Connector MCP Tools
-
-Create connectors that become AI-runnable commands:
-
-```bash
-# Add a test connector
-unispec connector new test "Run test suite" "pytest" "tests/" "-v"
-
-# Add a build connector  
-unispec connector new build "Build project" "cargo" "build"
-
-# Add a lint connector
-unispec connector new lint "Run linter" "ruff" "check" "."
-```
-
-Now your AI can run:
-- "Run the test connector"
-- "Execute build"
-- "Run lint and fix errors"
-
-### Connector Structure
-
-Connectors are defined in `.agent/config.toml`:
+Every connector defined in `.agent/config.toml` becomes an MCP tool named `unispec_<connector_name>`:
 
 ```toml
 [[connector]]
@@ -213,9 +106,7 @@ args = ["tests/", "-v"]
 timeout = 60
 ```
 
-### Connector Dynamic Tools
-
-Each connector automatically becomes an MCP tool named `unispec_<name>`:
+Exposes:
 
 ```json
 {
@@ -227,157 +118,30 @@ Each connector automatically becomes an MCP tool named `unispec_<name>`:
       "args": {
         "type": "array",
         "items": {"type": "string"},
-        "description": "Additional arguments to pass to the command"
+        "description": "Extra arguments appended to the connector command"
       }
     }
   }
 }
 ```
 
-### Running Connectors
+The implementation just shells out to `unispec connector run <name> -- <extra-args>` and returns combined stdout/stderr.
+
+## Starting the MCP server
 
 ```bash
-# Run a connector
-unispec connector run test
-
-# Run with arguments
-unispec connector run test -- -k "test_user"
-
-# List all connectors
-unispec connector list
-
-# Generate MCP config for connectors
-unispec connector mcp
-```
-
-### Per-Project Connectors
-
-Create connectors specific to your project:
-
-```bash
-# Custom build script
-unispec connector new deploy-prod "Deploy to production" "./scripts/deploy.sh" "prod"
-
-# Database migrations
-unispec connector new migrate "Run migrations" "alembic" "upgrade" "head"
-
-# Type checking
-unispec connector new typecheck "Type check project" "mypy" "src/"
-```
-
-These are stored in `./.agent/config.toml` and available to your AI editor.
-
-## Commands Not Available via MCP
-
-Some CLI commands are not exposed as MCP tools because they're used for project setup or configuration rather than runtime operations:
-
-| CLI Command | Reason not in MCP |
-|-------------|-------------------|
-| `unispec init` | One-time project initialization |
-| `unispec mode add` | Mode addition (manual config) |
-| `unispec mode remove` | Mode removal (manual config) |
-| `unispec connector new` | Connector creation (config-based) |
-| `unispec connector delete` | Connector deletion (config-based) |
-| `unispec connector edit` | Connector editing (config-based) |
-| `unispec pkg list/search/install/remove` | Package management (use CLI) |
-| `unispec patty enable/disable/status` | Mascot control (use CLI) |
-| `unispec index full` | Index statistics |
-| `unispec index watch` | Background watcher |
-
-## MCP Server
-
-Start the UniSpec MCP server for direct integration:
-
-```bash
+# Default: current directory as project root
 unispec mcp
+
+# Explicit root
+unispec mcp /path/to/project
 ```
 
-This starts an MCP server that tools like Claude Desktop can connect to.
+It speaks JSON-RPC over stdio. Each line is one complete JSON message.
 
-### Claude Desktop Config
+### Claude Desktop
 
-Add to `~/.config/claude/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "unispec": {
-      "command": "unispec",
-      "args": ["mcp", "./"]
-    }
-  }
-}
-```
-
-## Workflow Files
-
-When you init with an editor, UniSpec creates workflow files in your project:
-
-### Cursor/Windsurf
-
-Files created in `./.cursor/commands/unispec/`:
-
-```markdown
-# unispec:spec.md
-
-## When to use
-Use this workflow when starting a new feature.
-
-## Steps
-1. Check the spec for existing requirements
-2. Create a new topic if needed
-3. Write clear acceptance criteria
-4. Link relevant files
-```
-
-### Claude Code
-
-Files created in `./.claude/commands/unispec/`:
-
-```markdown
-# unispec-commands
-
-[TOOL_CALL]
-{
-  tool => 'unispec_list_topics',
-  args => {
-    --area Staging
-  }
-}
-[/TOOL_CALL]
-```
-
-### Cline
-
-Files created in `./.clinerules/workflows/unispec/`:
-
-```markdown
-# unispec-spec
-
-Run when user wants to create or review a spec.
-
-1. Check existing specs in ./spec/
-2. Create new topic if needed
-3. Use specs to guide implementation
-```
-
-### Manual IDE MCP Setup
-
-If you want to connect UniSpec MCP directly to your editor:
-
-#### Cursor
-1. Go to Settings → MCP
-2. Add new MCP server:
-   - Command: `unispec`
-   - Args: `mcp`
-   - Cwd: `./`
-
-#### Windsurf
-1. Go to Settings → Extensions → MCP
-2. Add server with same config as Cursor
-
-#### Claude Desktop
-Add to `~/.config/claude/settings.json`:
+`~/.config/claude/settings.json`:
 
 ```json
 {
@@ -385,18 +149,15 @@ Add to `~/.config/claude/settings.json`:
     "unispec": {
       "command": "unispec",
       "args": ["mcp"],
-      "env": {
-        "UNISPEC_ROOT": "./"
-      }
+      "env": { "UNISPEC_ROOT": "/abs/path/to/project" }
     }
   }
 }
 ```
 
-#### VS Code
-Use the MCP extension:
-1. Install "MCP" extension
-2. Add to settings.json:
+### Cursor / Windsurf / Continue / VS Code (MCP)
+
+Use the same shape:
 
 ```json
 {
@@ -404,53 +165,49 @@ Use the MCP extension:
     "unispec": {
       "command": "unispec",
       "args": ["mcp"],
-      "cwd": "./"
+      "cwd": "/abs/path/to/project"
     }
   }
 }
 ```
 
-## Custom MCP Integration
+For `unispec init --cursor` etc., UniSpec drops workflow files into the editor's commands directory. These are prose prompts, not MCP — they instruct the agent on which MCP tools to call.
 
-### For Custom Tools
+## Calling tools
 
-If your tool supports MCP, add UniSpec:
+Once connected, your agent can call tools by name. Example (Claude):
 
-```json
-{
-  "mcpServers": {
-    "unispec": {
-      "command": "path/to/unispec",
-      "args": ["mcp"],
-      "env": {
-        "UNISPEC_ROOT": "/path/to/project"
-      }
-    }
-  }
-}
+```
+"Read the spec for user-login in Working"
+→ unispec_read_spec { "topic": "user-login", "area": "Working" }
+
+"Mark task 2 of payment-api done"
+→ tasks_complete { "topic": "payment-api", "task_index": 1 }   # 0-based
+
+"Link src/auth/login.rs to user-login as an implementation"
+→ index_add { "topic": "user-login", "path": "src/auth/login.rs", "link_type": "implementation" }
 ```
 
-### Environment Variables
+## Argument quirks worth remembering
 
-| Variable | Description |
-|----------|-------------|
-| `UNISPEC_ROOT` | Project root (default: current dir) |
-| `UNISPEC_MODE` | Mode to use |
+- `topics_add` and `spec_add` **strip any frontmatter** you include in `content` / `spec_content` / `task_content` and prepend their own. Just provide the body.
+- `task_write` **fails** if the spec file doesn't already exist for that topic; call `spec_add` first.
+- `task_index` is **0-based** for `tasks_complete` and `tasks_incomplete`.
+- `topics_push` from `Staging` or `Fixing` **requires** the topic to appear in `<area>/queue.md`. Use `queue_check` before `topics_push`.
+- The default `area` for every tool that accepts one is `Staging`.
 
-## Tips
+## Environment variables
 
-1. **Start simple** - Just `unispec init --cursor` to begin
-2. **Link everything** - Use `unispec index add` to connect code to specs
-3. **Run connectors** - Make AI run your tests and builds
-4. **Update specs** - AI works better with accurate specs
+| Variable | Purpose |
+|----------|---------|
+| `UNISPEC_ROOT` | Override project root (default: current dir). |
+| `UNISPEC_MODE` | Override the active mode for this MCP session. |
 
 ---
 
-## See Also
+## See also
 
-- [Commands Reference](commands.md) - CLI command documentation
-- [Configuration Reference](configuration.md) - Config files, environment variables
-- [Modes Documentation](modes.md) - Custom workflow configurations
-- [Getting Started](getting-started.md) - Quick start guide
-
-*See modes.md to create custom modes with their own MCP workflows, or commands.md for CLI reference.*
+- [Commands Reference](commands.md)
+- [Configuration Reference](configuration.md)
+- [Modes](modes.md)
+- [Getting Started](getting-started.md)

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,6 +1,6 @@
 # Creating Modes
 
-Modes define how you work with UniSpec. The default "Simple Mode" uses Staging → Building → Ship. But you can create custom modes for different workflows.
+Modes define how you work with UniSpec. The shipped default mode (`.agent/modes/default/`) uses a five-area pipeline: `Staging → Working → Testing → Fixing → Build`. You can create custom modes for different workflows (kanban, sprint, RFC, docs).
 
 ## What is a Mode?
 
@@ -284,27 +284,29 @@ unispec pkg installed
 
 Packages can include modes, connectors, and workflows. See [Commands Reference](commands.md#pkg) for full details.
 
-## Mode Types
+## Common mode shapes
 
-### Simple Mode (Default)
-- Staging → Building → Ship
-- Good for: Solo devs, small teams
+These are typical pipelines; only `default` ships in the repo. The rest are examples you can build yourself or install from the community package repository.
+
+### Default Mode (shipped)
+- Staging → Working → Testing → Fixing → Build
+- Good for: spec-driven solo devs and small teams.
 
 ### Sprint Mode
 - Backlog → In Sprint → Review → Done
-- Good for: Agile teams, two-week cycles
+- Good for: agile teams on fixed cycles.
 
 ### Kanban Mode
 - To Do → In Progress → Code Review → Done
-- Good for: Continuous delivery, Ops teams
+- Good for: continuous-delivery and ops teams.
 
 ### Docs Mode
 - Draft → Review → Published
-- Good for: Documentation projects
+- Good for: documentation projects.
 
 ### RFC Mode
 - Proposed → Discussion → Approved/Rejected
-- Good for: Architecture decisions
+- Good for: architecture decisions.
 
 ## Sharing Modes
 
@@ -329,17 +331,17 @@ tar -xvzf my-mode.tar.gz -C /path/to/project/.agent/modes/
 
 ```toml
 [mode]
-name = "simple"
-display_name = "Simple Mode"
-description = "Default mode with Spec-Driven Development workflows. Staging: specs being written. Working: specs being built. Build: shippable code."
+name = "default"
+display_name = "Standardized Spec-Driven Mode"
+description = "Default UniSpec mode. Staging: writing specs. Working: building code. Testing: build/test runs. Fixing: repair. Build: shippable, immutable."
 version = "1.0.0"
 
 [author]
-name = "OpenSDD Team"
-contact = "https://github.com/osdd"
+name = "UniSpec Team"
+contact = "https://github.com/uwzis/UniSpec"
 
 [requirements]
-min_osdd_version = "0.9.0"
+min_unispec_version = "0.0.1"
 
 [areas]
 default = ["Staging", "Working", "Build"]

--- a/docs/spec-workflow.md
+++ b/docs/spec-workflow.md
@@ -1,194 +1,134 @@
-# Skill: UniSpec SPEC Workflow
+# SPEC Workflow
 
-**Act as a UniSpec Specification Architect.** Your goal is to create precise, actionable specs and tasks using the system templates.
-
----
-
-## Purpose
-This workflow is for creating, modifying, and arranging topics, specs, and tasks. Use this when planning new features, refining specifications, or organizing work.
+Use this workflow to create or refine a topic, its spec, and its task list — all in the `Staging` area. No code is written here.
 
 ---
 
-## KEY RULE: Topics First, Always!
+## Preconditions
 
-**Constraint: Before doing ANYTHING else, you MUST research topics first!**
+- You know the rough scope of the feature.
+- You can produce a one-line description (`short`) and a body for the topic, the spec, and the task list.
+
+If you don't have those yet, stop and ask the user. Do not invent requirements.
 
 ---
 
-## CREATE TOPICS → FILL TOPICS → CREATE SPECS → FILL SPECS
+## Tools used
 
-**CRITICAL: ALWAYS use MCP tools to create each item one at a time with full content matching the templates!**
+All literal MCP tool names:
 
-### Step 1: Create Topics Using topics_add MCP Tool
+- `read_asset { topic: "templates", asset_type: "topic" | "spec" | "task" }` — read the template body to mirror.
+- `topics_add { topic, area, short, content }` — creates `spec/<area>/<topic>/topic.md`.
+- `spec_add { topic, area, short, spec_content, task_content }` — creates `<topic>_spec.md` and `<topic>_task.md` in the same directory.
+- `queue_add { topic, area }` — register the topic in `spec/Staging/queue.md` so it can later be pushed.
 
-**Format: Use the topic.md template structure**
+The server prepends frontmatter to every file. Pass body text only — no leading `---` block.
+
+---
+
+## Steps
+
+### 1. Read the templates
 
 ```
-topics_add {topic: "auth", area: "Staging", content: "---
-title: auth
-created: 2026-04-08 10:00:00
-author: Your Name
----
-
-# auth
-
-## Overview
-[What this topic covers - high-level summary in 1-2 sentences]
-
-## Purpose
-[Why this topic exists - what problem it solves, who benefits]
-
-## Specs
-- [spec name]: [What this spec covers]
-
-## Sub-topics
-- [sub-topic name]
-"}
+read_asset { topic: "templates", asset_type: "topic" }
+read_asset { topic: "templates", asset_type: "spec" }
+read_asset { topic: "templates", asset_type: "task" }
 ```
 
-**Constraint: Never create an empty topic. Always provide full content matching the template.**
+These return the canonical structure each file should have. Mirror the section headings exactly; fill the body with real, project-specific content.
 
-### Step 2: Create Specs Using spec_add MCP Tool
-
-**Format: Use the spec.md template exactly. Include all sections:**
+### 2. Create the topic
 
 ```
-spec_add {topic: "auth/login", area: "Staging", content: "---
-title: auth/login
-created: 2026-04-08 10:00:00
-author: Your Name
-status: draft
----
-
-# Design: auth/login
-
-## Overview
-
-> High-level summary: What is this feature in 1-2 sentences?
-
-## Purpose
-
-> Why does this feature exist? What problem does it solve? Who benefits?
-
-## In-Depth Details
-
-> Technical explanation: How does it work? What are the components? What are the key decisions?
-
-## Requirements
-
-| ID | Requirement | Priority |
-|----|-------------|----------|
-| REQ-001 | [Requirement statement] | Must/Should |
-
-## Examples
-
-### Example 1: [Name]
-- **Input**: [What goes in]
-- **Output**: [What comes out]
-- **Flow**:
-  1. [Step 1]
-  2. [Step 2]
-
-## Data Model
-
-### Entities
-
-| Entity | Fields | Description |
-|--------|--------|-------------|
-| [Name] | [field]: [type] | [description] |
-
-### Relationships
-
-```
-[EntityA] ──1:N──> [EntityB]
+topics_add {
+  topic: "<topic-name>",
+  area: "Staging",
+  short: "<one-line description>",
+  content: "<body matching templates/topic.md — Overview, Specs, Sub-topics, Notes>"
+}
 ```
 
-## Out of Scope
+Constraints enforced by the server:
+- `content` must be ≥ 10 characters of real text.
+- `short` is required and non-empty.
+- Do **not** include `---` frontmatter in `content`. The server writes `title`, `short`, `created`, `author`.
 
-- [What this spec does NOT cover]
-- [What belongs in a different spec]
+Nested topics use `/`, e.g. `auth/login`. The directory becomes `spec/Staging/auth/login/` and the parent (`auth`) must already exist as a topic.
 
-## Acceptance Criteria
+### 3. Create the spec and task files
 
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-", task_content: "---
-spec: auth/login
-created: 2026-04-08
-status: pending
-date: 2026-04-08
----
-
-# Tasks: auth/login
-
-## Implementation
-
-### Phase 1: Foundation
-- [ ] **1.1** [Foundation task - e.g., Set up project structure]
-
-### Phase 2: Core Features
-- [ ] **2.1** [Core feature task - e.g., Implement login form]
-
-### Phase 3: Integration
-- [ ] **3.1** [Integration task - e.g., Connect to authentication service]
-
-### Phase 4: Polish
-- [ ] **4.1** [Polish task - e.g., Add error handling]
-
-## Notes
-
-<!-- Implementation notes, decisions, and blockers -->
-
-<!--
-Date format: YYYY-MM-DD
-Example:
-**2024-01-15**: Chose approach A over B because X
--->
-"}
+```
+spec_add {
+  topic: "<topic-name>",
+  area: "Staging",
+  short: "<one-line description>",
+  spec_content: "<body matching templates/spec.md — Overview, Purpose, In-Depth Details, Requirements, Examples, Data Model, Out of Scope>",
+  task_content: "<body matching templates/task.md — Implementation phases only, no test tasks>"
+}
 ```
 
-**Constraint: Follow the task.md template EXACTLY. Only create IMPLEMENTATION tasks - NO testing tasks!**
+Both `spec_content` and `task_content` are required and must each be ≥ 10 characters. The server strips any `---` block you include and prepends correct frontmatter.
+
+Filenames produced (slashes and spaces in `topic` are converted to `-`):
+- `<topic>_spec.md`
+- `<topic>_task.md`
+
+### 4. Register in the readiness queue
+
+```
+queue_add { topic: "<topic-name>", area: "Staging" }
+```
+
+This is required for the BUILD workflow to later `topics_push` the topic to Working.
 
 ---
 
-## CRITICAL: NO TESTING TASKS IN SPEC PHASE!
+## Content rules
 
-**Constraint: NEVER create testing tasks during the SPEC workflow!**
-
-Testing tasks are ONLY created in the BUILD phase, right before pushing to Testing.
-
-- ❌ DO NOT add "write tests", "run tests", "test functionality" tasks
-- ✅ DO add implementation tasks like "implement login form", "connect to API"
-
-**Remember: Testing comes LATER in the BUILD phase.**
+- **Specs describe WHAT, not HOW.** Requirements use SHALL/SHOULD; acceptance criteria are checkable.
+- **Tasks describe implementation steps only.** No "write tests", "QA the feature", or similar. Test tasks are added during BUILD, after implementation.
+- **One topic = one bounded scope.** If you find yourself listing five unrelated capabilities, split into sub-topics (`feature/sub-a`, `feature/sub-b`).
+- **No placeholder text in the final body.** Strings like `[Requirement statement]` or `[Foundation task]` exist in the template to be replaced, not committed.
 
 ---
 
-## Complete Example Flow
+## Definition of done
 
-**Use MCP tools ONE AT A TIME with content matching templates:**
+A topic is done with SPEC when **all** of these hold:
 
-```
-# 1. Research first
-topics_list {area: "Staging"}
+- `spec/Staging/<topic>/topic.md` exists and has a real `short` and Overview.
+- `spec/Staging/<topic>/<topic>_spec.md` exists with every template section filled with non-placeholder content.
+- `spec/Staging/<topic>/<topic>_task.md` exists with at least one concrete implementation task and no test tasks.
+- The topic appears in `spec/Staging/queue.md` (verify with `queue_check`).
+- `topics_show { topic, area: "Staging" }` lists `topic.md`, `<topic>_spec.md`, and `<topic>_task.md`.
 
-# 2. Create topic WITH full content (matching template)
-topics_add {topic: "auth", area: "Staging", content: "..."}
-
-# 3. Create spec WITH full content AND task WITH full content (both matching templates)
-spec_add {topic: "auth/login", area: "Staging", content: "...", task_content: "..."}
-```
+If any condition fails, the topic is not ready for BUILD.
 
 ---
 
-## Key Rules
+## Example: full sequence
 
-1. **ALWAYS work in Staging area**
-2. **ALWAYS start with topics**
-3. **Use MCP tools** - topics_add, spec_add with content/task_content params
-4. **Create + Fill = ONE action** - Never separate them
-5. **Follow templates EXACTLY** - Use the spec.md and task.md template structure
-6. **One at a time** - Complete one piece before starting the next
-7. **Use nested topics with `/`**
-8. **NO TESTING TASKS** - Only create IMPLEMENTATION tasks. Testing is handled in the BUILD phase.
-9. **Verify against template** - Always ensure your spec/task matches the template format
+```
+read_asset  { topic: "templates", asset_type: "spec" }
+read_asset  { topic: "templates", asset_type: "task" }
+
+topics_add {
+  topic: "user-login",
+  area: "Staging",
+  short: "Email/password login with JWT session",
+  content: "# user-login\n\n## Overview\nLogin flow for the customer portal — email + password, JWT issued on success.\n\n## Specs\n- `user-login_spec.md`: login flow design and data model.\n\n## Sub-topics\n- (none yet)\n\n## Notes\n- Password reset is out of scope; tracked under `account-recovery`."
+}
+
+spec_add {
+  topic: "user-login",
+  area: "Staging",
+  short: "Email/password login with JWT session",
+  spec_content: "# Design: user-login\n\n## Overview\nUsers submit email + password; server returns a signed JWT.\n\n## Purpose\nAuthenticate returning customers without third-party identity providers.\n\n## In-Depth Details\n- Passwords stored with argon2id.\n- JWT signed with HS256, 30-min expiry, refresh via /token endpoint.\n\n## Requirements\n| ID | Requirement | Priority |\n|----|-------------|----------|\n| REQ-001 | The service SHALL accept POST /login with {email, password}. | Must |\n| REQ-002 | The service SHALL return 401 on bad credentials within 200ms. | Must |\n| REQ-003 | The service SHOULD lock an account after 5 failed attempts in 5 min. | Should |\n\n## Examples\n### Example 1: Successful login\n- Input: {email: \"a@b.com\", password: \"...\"}\n- Output: 200 with {jwt: \"...\"}\n\n## Data Model\n### Entities\n| Entity | Fields | Description |\n|--------|--------|-------------|\n| User | id, email, password_hash, locked_until | One row per customer. |\n\n## Out of Scope\n- Password reset (see account-recovery).\n- SSO.",
+  task_content: "# Tasks: user-login\n\n## Implementation\n\n### Phase 1: Foundation\n- [ ] **1.1** Add User table + migration.\n\n### Phase 2: Core Features\n- [ ] **2.1** Implement POST /login handler.\n- [ ] **2.2** Implement JWT signing helper.\n\n### Phase 3: Integration\n- [ ] **3.1** Wire handler into router with rate-limit middleware.\n\n### Phase 4: Polish\n- [ ] **4.1** Add structured logging on failure.\n\n## Notes\n"
+}
+
+queue_add { topic: "user-login", area: "Staging" }
+```
+
+After this, the BUILD workflow can pick up `user-login` from the queue and push it to Working.

--- a/docs/system-prompt.md
+++ b/docs/system-prompt.md
@@ -1,299 +1,183 @@
-# Skill: UniSpec System Prompt
+# UniSpec System Prompt
 
-## Overview
-UniSpec is a spec-driven development workflow system. It uses a 5-area pipeline and tracks all work through topics, specs, tasks, and an index that links code files to specifications.
+UniSpec is a spec-driven development workflow. Each topic moves through a fixed pipeline of areas (default: `Staging → Working → Testing → Fixing → Build`), and every code file is linked to the spec it implements.
 
----
-
-## KEY RULE: Topics First, Always!
-
-**Before doing ANYTHING in UniSpec, you MUST start with topics!**
-
-1. **ALWAYS start by listing topics** - Never assume you know the project structure
-   ```
-   topics_list {area: "Staging"}
-   topics_list {area: "Working"}
-   ```
-
-2. **ALWAYS read the topic first** - Before writing specs or code, secure the scope
-   ```
-   topic_read {topic: "<topic-name>", area: "Staging"}
-   ```
-
-3. **Topics define scope** - Each topic bounds:
-   - What specs can be created under it
-   - What code should be built in it
-   - The overall project structure
-
-**This is MANDATORY for every workflow:**
-
-- **SPEC workflow:** Research topics → Understand scope → Then create specs
-- **BUILD workflow:** Research topics → Understand scope → Then build code
-- **Any other workflow:** Topics first!
+This prompt is the contract between you and the UniSpec MCP server. Tool names and parameters here must be used verbatim.
 
 ---
 
-## The 5 Areas (Pipeline Stages)
+## 1. Start every session by orienting
 
-Work flows through these areas in order:
-
-1. **Staging** - New ideas, initial specs, architectural planning
-2. **Working** - Active development and implementation
-3. **Testing** - Code verification, running tests
-4. **Fixing** - Resolving issues and bugs
-5. **Build** - Ready for final build/deployment
-
----
-
-## Mode: Read-Only vs Write
-
-### Read-Only Mode (Default)
-- **DO NOT create, modify, or delete any files**
-- Use MCP tools to understand state
-- Wait for explicit permission to write files
-
-### Write Mode (When Permitted)
-- The system will tell you when you can create files
-- Look for messages like: "You are no longer in read-only mode"
-- When in write mode, you may write spec.md, task.md, code files, etc.
-
----
-
-## SPEC Workflow: Plan Mode (Default in SPEC)
-
-### Step 1: List Specs/Requirements
-Summarize current understanding of the project:
+Before doing anything else, learn the current state:
 
 ```
-# Get overview
 areas_list
 topics_list {area: "Staging"}
 topics_list {area: "Working"}
-queue_list
+queue_list {area: "Working"}
 ```
 
-Output a summary of:
-- Active topics and their specs
-- Current area assignments
-- Queue priority
-- Overall project state
+Do not assume area names or topic names from prior conversations — they may have changed. The default area for `topics_list`, `topics_progress`, `queue_*`, and most other tools is `Staging`.
 
-### Step 2: Clarify via Questions
-Ask targeted questions using numbered bullet format:
+---
 
-1. What specific functionality is needed for this feature?
-2. What data structures or models should this use?
-3. Are there any existing implementations to reference?
-4. What are the success criteria for this feature?
-5. Are there any constraints or dependencies?
+## 2. Use real tool names
 
-### Step 3: Plan Formulation
-When requirements are clear, create a structured plan document with:
-- **Project Overview**: Purpose, scope, and goals
-- **Technical Architecture**: High-level design and system components
-- **Data Model Design**: Core data structures and interfaces
-- **Implementation Roadmap**: Ordered steps with dependencies (no timeframes - just list what needs to happen)
-- **Risk Assessment**: Potential challenges and mitigations
+The MCP server publishes the tools below. Tools not in this list do not exist; do not call them.
 
-### Step 4: Ready to Build?
-When the plan is complete and you're ready to create the spec:
+### Reading
+- `areas_list` — `{}`
+- `topics_list {area?}`
+- `topics_show {topic, area?}`
+- `topics_progress {area?}`
+- `read_asset {topic, asset_type, area?}` — `asset_type` is `"topic"`, `"spec"`, or `"task"`. Use `topic: "templates"` to read the templates in `.agent/modes/default/templates/`.
+- `unispec_read_spec {topic, area?}` — returns spec + task content together.
+- `tasks_list {topic, area?}`
+- `notes_read {topic, area?}`
+- `queue_list {area?}`
+- `queue_check {topic, area?}`
+- `index_list {topic?, path?, tag?}`
+- `index_find {query, by?}` — `by`: `topic` (default), `path`, or `tag`.
+- `index_lookup {id}` — `id` is `topic:name`.
+- `index_graph {}`
+- `index_backlinks {topic}`
 
-**Tell the user:**
-> "This plan is ready to build! When you're ready, run `unispec spec` and I'll create the topic in Staging, write the spec.md file with the specification, and move it to Working for implementation."
+### Writing
+- `topics_add {topic, area, short, content}` — all four required. `content` must be ≥ 10 chars. Don't include frontmatter; the server writes it.
+- `spec_add {topic, area, short, spec_content, task_content}` — all five required. Creates `<topic-with-dashes>_spec.md` and `<topic-with-dashes>_task.md`. Server replaces `/` and ` ` in `topic` with `-` for the filenames.
+- `spec_write {topic, area?, content}` — overwrite existing spec.
+- `task_write {topic, area?, content}` — overwrite existing task file. **Fails if no spec exists yet** — call `spec_add` first.
+- `task_status {topic, status, area?}` — `status` ∈ {`pending`, `working`, `complete`}. Updates the frontmatter field only.
+- `tasks_complete {topic, task_index, note?, area?}` — flip a task to `[x]`. `task_index` is 0-based.
+- `tasks_incomplete {topic, task_index, note?, area?}` — flip a task back to `[ ]`.
+- `notes_add {topic, note, area?}` — append to the notes block.
+- `topics_delete {topic, area?, force?}`
+- `topics_push {topic, area, source_area?}` — gated on `queue.md` if the source area is Staging or Fixing.
+- `topics_pull {topic, source_area}` — pulls into `Working`.
+- `queue_add {topic, position?, area?}` — `position: 0` is first; `-1` (default) is last.
+- `queue_remove {topic, area?}`
+- `queue_reorder {topic, new_position, area?}`
+- `index_add {topic, path, area?, link_type?, tags?, annotation?}`
+- `unispec_bind_spec {spec_path, file_path, topic, area?}`
 
-This signals:
-- Spec creation is ready
-- User should run the spec command
-- Next steps are clear
+That's the whole MCP surface. Use the host editor's Read/Write tools only for things outside `spec/` (source files in `src/`, configs, etc.) — never to write `topic.md`, `*_spec.md`, or `*_task.md` directly.
 
-**Do NOT print a roadmap** - just output the spec.
+---
 
-### Step 4: Create Topic (when plan approved)
+## 3. Two execution modes
+
+### Plan mode (default)
+Use the reading tools above to summarize state, identify gaps, and propose a path forward. Do not write any files. End plan turns by stating exactly which write tool you would call next, with the full argument object.
+
+### Write mode (user opts in)
+The user signals "go ahead" or names a specific writing tool. Then execute the plan with the writing tools. Confirm each MCP call's success before moving to the next.
+
+---
+
+## 4. The pipeline
+
 ```
-topics_add {topic: "feature-name", area: "Staging"}
+Staging  → write specs and tasks
+Working  → implement; flip task checkboxes; link new files
+Testing  → run build/tests (queue.md is removed on entry)
+Fixing   → debug; once fixed, push back to Testing
+Build    → final, treat as immutable
 ```
 
-### Step 5: Create Spec & Tasks
-Use `spec_add` to create both spec.md and task.md from templates in one step:
+A topic must be in `spec/<source-area>/queue.md` to be pushable out of Staging or Fixing. Always run `queue_check` before `topics_push` from those areas; if `ready: false`, call `queue_add` first.
+
+---
+
+## 5. Standard workflow
+
+### Plan a new feature
+1. `topics_list {area: "Staging"}` — what already exists?
+2. Clarify with the user (one question at a time):
+   - What problem does this solve?
+   - What's the smallest shippable scope?
+   - What's explicitly out of scope?
+   - What's the one-line summary (you'll pass it as `short`)?
+3. State the exact `topics_add` and `spec_add` calls you intend to make.
+
+### Create the spec
 ```
-spec_add {topic: "feature-name", area: "Staging"}
+topics_add {
+  topic: "<name>",
+  area: "Staging",
+  short: "<one-line description>",
+  content: "<topic body — overview, sub-topics, notes>"
+}
+
+spec_add {
+  topic: "<name>",
+  area: "Staging",
+  short: "<one-line description>",
+  spec_content: "<full Design body matching templates/spec.md>",
+  task_content: "<full Tasks body matching templates/task.md — implementation tasks only>"
+}
+
+queue_add { topic: "<name>", area: "Staging" }
 ```
 
-### Step 6: Add to Queue
+Do **not** write the `---` frontmatter inside `content`, `spec_content`, or `task_content` — the server prepends it automatically.
+
+### Implement
 ```
-queue_add {topic: "feature-name", position: 0}
-# EDIT ONLY IN STAGING - Do NOT push to Working
+queue_check { topic: "<name>", area: "Staging" }    # confirm ready
+topics_push { topic: "<name>", area: "Working" }
+
+unispec_read_spec { topic: "<name>", area: "Working" }
+tasks_list       { topic: "<name>", area: "Working" }
+task_status      { topic: "<name>", area: "Working", status: "working" }
+
+# for each task you finish:
+tasks_complete   { topic: "<name>", task_index: <N> }
+index_add        { topic: "<name>", path: "src/<file>", link_type: "implementation" }
+notes_add        { topic: "<name>", note: "<decision not in spec>" }    # only when relevant
+```
+
+### Hand off to testing
+```
+queue_add    { topic: "<name>", area: "Working" }   # if Working requires queue in your mode
+topics_push  { topic: "<name>", area: "Testing" }
 ```
 
 ---
 
-## Core Concepts
-
-### Topics
-A **topic** is a unit of work - a feature, bug fix, or project. Each topic lives in one area and contains:
-- `spec.md` - The specification document
-- `task.md` - The task list with completion status
-- Notes section at bottom of task.md
-
-### The Index
-The **index** tracks relationships between specs and code files:
-- Links files to topics with metadata (tags, annotation, type)
-- Enables finding "what spec does this file implement?"
-- Enables finding "what files implement this spec?"
-- Full graph visualization available
-
-### The Queue
-The **queue** (`queue.md`) is an ordered list of topics to work on:
-- Prioritized work list
-- Topics can be added, removed, reordered
-
----
-
-## MCP Tools Reference
-
-**Use these tools for all operations.**
-
-### Area & Topic Management
-- `areas_list` - List all areas (Staging, Working, Testing, Fixing, Build)
-- `topics_list [area]` - List topics in an area
-- `topics_add {topic, area}` - Create new topic (creates folder structure only)
-- `topics_delete {topic, area, force}` - Delete topic
-- `topics_show {topic, area}` - Show topic files and structure
-- `topics_push {topic, area, source_area}` - Move topic to another area
-- `topics_pull {topic, source_area}` - Pull topic from another area into Working
-- `topics_progress [area]` - Show completion progress across topics
-
-### Spec & Tasks
-- `spec_add {topic, area}` - Create *_spec.md and *_task.md from templates (area: Staging)
-- `spec_read {topic, area}` - Read spec content (area: Staging)
-- `spec_write {topic, area, content}` - Write spec content
-- `task_read {topic, area}` - Read task content (area: Staging)
-- `task_write {topic, area, content}` - Write full task content
-- `task_status {topic, area, status}` - Update task status: pending, working, or complete
-- `tasks_list {topic, area}` - List all tasks with status
-
-### Notes
-- `notes_read {topic, area}` - Read notes section from task.md
-- `notes_add {topic, note, area}` - Add a note to notes section
-
-### Queue (Ordered Work List)
-- `queue_list [area]` - List ordered queue of topics (area: Staging)
-- `queue_add {topic, position, area}` - Add to queue (0=first, -1=last)
-- `queue_remove {topic, area}` - Remove from queue
-- `queue_reorder {topic, new_position, area}` - Reorder queue
-
-### Index (File ↔ Spec Linking)
-- `index_add {topic, path, area, link_type, tags, annotation}` - Link file to topic
-- `index_find {query, by}` - Find links by topic/path/tag
-- `index_lookup {id}` - Find export by full ID (topic:name)
-- `index_list [topic, path, tag]` - List all index links with filters
-- `index_graph` - Export full relationship graph JSON
-- `index_backlinks {topic}` - Generate backlinks for a topic
-- `unispec_bind_spec {spec_path, file_path, topic, area}` - Bind code file to spec
-
----
-
-## Standard Workflow
-
-### 1. Start Work
-```
-# Check queue for prioritized work
-queue_list
-
-# Check what's in Working area
-topics_list {area: "Working"}
-
-# Get the spec for the topic you're working on
-spec_read {topic: "feature-name", area: "Working"}
-
-# See tasks for this topic
-tasks_list {topic: "feature-name", area: "Working"}
-```
-
-### 2. Implement
-```
-# Mark task as working
-task_status {topic: "feature-name", area: "Staging", status: "working"}
-
-# Do the work, mark tasks complete when done
-task_status {topic: "feature-name", area: "Staging", status: "complete"}
-
-# If you need to modify the spec:
-spec_write {topic: "feature-name", area: "Staging", content: "..."}
-
-# Add implementation notes
-notes_add {topic: "feature-name", note: "Using JWT tokens for auth"}
-```
-
-### 3. Complete
-```
-# When done, mark as complete
-task_status {topic: "feature-name", area: "Staging", status: "complete"}
-```
-
-### 4. Verify
-```
-# See full picture
-index_graph
-
-# Find what's linked to a spec
-index_find {query: "feature-name", by: "topic"}
-
-# Get backlinks
-index_backlinks {topic: "feature-name"}
-
-# Check progress
-topics_progress {area: "Working"}
-```
-
----
-
-## Key Principles
-
-1. **Default: Do NOT create files** - Wait for permission to write
-
-2. **Use MCP tools first** - Only use direct file operations when MCP tools cannot do what you need
-
-3. **Plan first** - List, clarify, plan before writing specs
-
-4. **Read the spec before coding** - Always use `unispec_read_spec` to understand requirements
-
-5. **Track progress with tasks** - Mark tasks complete as you finish them
-
-6. **Link files to specs** - Use `index_add` for every file created so relationships are tracked
-
-7. **Use the queue** - Maintain prioritized work list
-
-8. **Move work through areas** - Push to next area when ready
-
-9. **Verify with index** - Use graph and backlinks to understand full picture
-
----
-
-## File Structure
+## 6. File layout the tools create
 
 ```
 spec/
-├── area.md                    # Area metadata (optional)
-├── master.md                  # Project master spec (optional)
-├── queue.md                   # Ordered work queue
-├── Staging/
-│   └── topic-name/
-│       └── spec.md, task.md
-├── Working/
-│   └── topic-name/
-│       ├── spec.md
-│       └── task.md
-├── Testing/
-├── Fixing/
-└── Build/
+├── <Area>/
+│   ├── area.md
+│   ├── queue.md
+│   └── <topic>/
+│       ├── topic.md
+│       ├── <topic>_spec.md
+│       └── <topic>_task.md
 ```
+
+For nested topics (`auth/login`), the spec file becomes `auth-login_spec.md` and the task file `auth-login_task.md`, both inside `spec/<Area>/auth/login/`.
 
 ---
 
-## Notes
-- Task indices are 0-based (first task is index 0)
-- Area names are case-insensitive internally
-- The queue defaults to showing topics by modification date if queue.md doesn't exist
-- Always check the queue before starting new work
-- **Wait for write mode permission before creating files**
+## 7. Definition of done
+
+A turn is complete when:
+- Every state change you intended has a confirmed MCP response.
+- Every task you finished is `[x]` (via `tasks_complete`).
+- `task_status` reflects whether the topic is `pending`, `working`, or `complete`.
+- Every file you wrote outside `spec/` is registered via `index_add`.
+- Any divergence from the spec is captured via `notes_add`.
+- If the topic is ready for the next area, you either called `topics_push` or named the specific blocker that prevents the push.
+
+---
+
+## 8. Failure modes to avoid
+
+- Calling `task_write` before a spec exists — it returns an error. Use `spec_add` first.
+- Calling `topics_push` from Staging without `queue_add` — gated by `queue.md`.
+- Hand-writing `---` frontmatter inside `content` / `spec_content` / `task_content` — it gets stripped, but it's cleaner to omit it.
+- Using `topic_read`, `spec_read`, or `task_read` — none of these exist. Use `read_asset` or `unispec_read_spec`.
+- Using `index_callers`, `index_remove`, `index_cleanup`, `index_tags`, `index_exports`, `index_query`, or `index_depends` as MCP tools — they are CLI commands only, not in the MCP surface.
+- Editing topic/spec/task files via the host's Write tool — bypasses frontmatter and breaks `tasks_list` / `task_status`.


### PR DESCRIPTION
## What this PR does

Rewrites every agent prompt, workflow file, template, and MCP documentation in the repo to use only tools that actually exist in src/mcp/mod.rs. The original prompts referenced invented tools like unispec_nav, unispec_update_task, unispec_auto_test, and unispec_query_relations. They also contained placeholder strings that agents would copy literally into tool calls.

Changes:
- All workflow files now reference only real MCP tools verified against src/mcp/mod.rs
- Every workflow has concrete steps, a definition of done, and a failure modes section
- Templates updated to explain what agents must replace vs what the server auto-generates
- MCP docs corrected: removed fake tools areas_add, areas_remove, config_get, mode_*, index_exports, index_query, index_depends
- docs/mcp.md now lists the real 31-tool surface with required args
- Area files, skill files, system prompts all updated to match actual server behavior
- CONTRIBUTING.md rebranded from OpenSDD to UniSpec with correct commands
- README.md areas table corrected to the actual 5-area pipeline

## Bugs found during audit

While auditing the prompts against the source code I found the following issues in the codebase. Flagging them here so you can fix them separately.

**Broken MCP tools** — these are advertised by get_tools() in src/mcp/mod.rs but have no match arm in server.rs::call_tool and return Unknown tool error:
- tasks_list
- tasks_complete
- tasks_incomplete
- notes_read
- notes_add
- queue_reorder

**unispec_read_spec always returns empty content** — spec_add writes files named topic_spec.md and topic_task.md but unispec_read_spec reads spec.md and task.md based on mode.toml config. The filename mismatch means every call silently returns empty strings via unwrap_or_default.

**read_asset with asset_type spec or task also fails** — same filename mismatch as above.

**unispec init creates 3 areas not 5** — init.rs hardcodes Staging, Working, Build. The Testing and Fixing areas in the documented pipeline do not exist after init. Any topics_push to Testing or Fixing will fail with area not found.

**topics_push copies, does not move** — the original topic remains in the source area after push. Docs and prompts that say move are wrong.

**mode.toml delete_files config is dead** — the queue.md deletion on Testing entry described in the mode config is never executed in push.rs.

These bugs are not in scope for this PR but I wanted to flag them since they affect whether any agent can complete an end-to-end workflow.