### PR TITLE
fix: topic add respects config area, add spec add CLI command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -181,12 +181,9 @@ pub enum Commands {
         /// Project directory to run MCP server for
         path: Option<PathBuf>,
     },
-    /// View the master spec
-    Spec {
-        /// Show master spec (default)
-        #[arg(default_value = "master")]
-        name: Option<String>,
-    },
+    /// Spec commands (show, add)
+    #[command(subcommand)]
+    Spec(SpecCommands),
     /// Agent mode commands
     #[command(subcommand)]
     Mode(ModeCommands),
@@ -401,6 +398,35 @@ pub enum AreaOrderCommands {
     },
     /// Reset order to default (no custom order)
     Reset,
+}
+
+#[derive(Subcommand)]
+pub enum SpecCommands {
+    /// Show the master spec (`spec/master.md`)
+    Show {
+        /// Spec name (default: master)
+        #[arg(default_value = "master")]
+        name: Option<String>,
+    },
+    /// Create a spec + task file for a topic
+    Add {
+        /// Topic name (use `parent/child` for nested topics)
+        #[arg(short, long)]
+        topic: String,
+        /// Area for the topic. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
+        /// One-line description (required)
+        #[arg(short, long)]
+        short: String,
+        /// Full spec body (matches the spec template). Required, ≥ 11 chars.
+        #[arg(long)]
+        spec_content: String,
+        /// Full task body (matches the task template). Required, ≥ 11 chars.
+        #[arg(long)]
+        task_content: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -409,9 +409,10 @@ pub enum TopicCommands {
     Add {
         /// Name of the topic to create
         topic: String,
-        /// Area to create the topic in (default: Working)
-        #[arg(short, long, default_value = "Working")]
-        area: String,
+        /// Area to create the topic in. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
         /// Short one-line description (required)
         #[arg(short, long)]
         short: String,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod pull;
 pub mod push;
 pub mod repo;
 pub mod set;
+pub mod spec;
 pub mod topic;

--- a/src/commands/spec.rs
+++ b/src/commands/spec.rs
@@ -1,0 +1,148 @@
+// src/commands/spec.rs
+//
+// Shared logic for creating a spec + task file for a topic. Used by both the
+// CLI (`unispec spec add ...`) and the MCP server (`spec_add` tool).
+//
+// Behaviour (preserved verbatim from the original MCP handler):
+// - `topic` may contain `/` for nested topics. The parent must already exist.
+// - `area` defaults to "Staging" when callers pass `None`. Case is preserved as
+//   provided; the function will fall back to the lowercase variant if the
+//   uppercased directory does not exist.
+// - `short` is required and non-empty.
+// - `spec_content` and `task_content` must each be at least 11 characters
+//   (`>10`) after trimming.
+// - Any leading `---` frontmatter block the caller includes in content is
+//   stripped before the function prepends its own canonical frontmatter.
+// - Files are written as `<topic-safe>_spec.md` and `<topic-safe>_task.md`
+//   where `topic-safe = topic.replace('/', "-").replace(' ', "-")`.
+
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub struct SpecAddOutput {
+    pub topic: String,
+    pub area: String,
+    pub spec_file: String,
+    pub task_file: String,
+    pub spec_path: PathBuf,
+    pub task_path: PathBuf,
+}
+
+/// Strip a leading `---` YAML frontmatter block from `content` if one is
+/// present. The first line must start with `---`; the block ends at the next
+/// line beginning with `---`.
+fn strip_frontmatter(content: &str) -> &str {
+    if content.trim_start().starts_with("---") {
+        if let Some(end) = content.find("\n---") {
+            return &content[end + 5..];
+        }
+    }
+    content
+}
+
+pub fn run_spec_add(
+    topic: &str,
+    area: Option<&str>,
+    short: &str,
+    spec_content: &str,
+    task_content: &str,
+) -> Result<SpecAddOutput> {
+    let area = area.unwrap_or("Staging");
+
+    let short = short.trim();
+    if short.is_empty() {
+        return Err(anyhow::anyhow!("'short' parameter is required and must be non-empty"));
+    }
+
+    let spec_content = spec_content.trim();
+    if spec_content.len() <= 10 {
+        return Err(anyhow::anyhow!(
+            "'spec_content' must be at least 11 characters of actual text"
+        ));
+    }
+
+    let task_content = task_content.trim();
+    if task_content.len() <= 10 {
+        return Err(anyhow::anyhow!(
+            "'task_content' must be at least 11 characters of actual text"
+        ));
+    }
+
+    // For nested topics ("auth/login"), verify the parent topic directory
+    // exists before we create a child inside it.
+    if topic.contains('/') {
+        let parts: Vec<&str> = topic.split('/').collect();
+        if parts.len() >= 2 {
+            let parent_topic = parts[0];
+            let parent_upper = crate::fs::spec_dir().join(area).join(parent_topic);
+            let parent_lower = crate::fs::spec_dir()
+                .join(area.to_lowercase())
+                .join(parent_topic);
+            if !parent_upper.exists() && !parent_lower.exists() {
+                return Err(anyhow::anyhow!(
+                    "Parent topic '{}' does not exist. Create it first with: \
+                     unispec topic add {} --area {} --short \"…\" --content \"…\"",
+                    parent_topic,
+                    parent_topic,
+                    area
+                ));
+            }
+        }
+    }
+
+    // Topic-safe filename component (matches the original MCP handler).
+    let topic_safe = topic.replace('/', "-").replace(' ', "-");
+    let spec_filename = format!("{}_spec.md", topic_safe);
+    let task_filename = format!("{}_task.md", topic_safe);
+
+    // Resolve / create the topic directory, supporting nested paths.
+    let spec_dir = {
+        let upper = crate::fs::spec_dir().join(area).join(topic);
+        if upper.exists() {
+            upper
+        } else {
+            let lower = crate::fs::spec_dir().join(area.to_lowercase()).join(topic);
+            if lower.exists() {
+                lower
+            } else {
+                std::fs::create_dir_all(&upper)?;
+                upper
+            }
+        }
+    };
+
+    let cleaned_spec = strip_frontmatter(spec_content).trim_start();
+    let cleaned_task = strip_frontmatter(task_content).trim_start();
+
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let author = crate::commands::topic::get_agent_id();
+
+    let spec_frontmatter = format!(
+        "---\ntitle: {}\nshort: {}\ncreated: {}\nauthor: {}\nstatus: draft\n---\n\n",
+        topic, short, now, author
+    );
+    let task_frontmatter = format!(
+        "---\nspec: {}\nshort: {}\nstatus: pending\ndate: {}\n---\n\n",
+        topic,
+        short,
+        now.split(' ').next().unwrap_or(&now)
+    );
+
+    let spec_full = format!("{}{}", spec_frontmatter, cleaned_spec);
+    let task_full = format!("{}{}", task_frontmatter, cleaned_task);
+
+    let spec_path = spec_dir.join(&spec_filename);
+    let task_path = spec_dir.join(&task_filename);
+
+    std::fs::write(&spec_path, spec_full)?;
+    std::fs::write(&task_path, task_full)?;
+
+    Ok(SpecAddOutput {
+        topic: topic.to_string(),
+        area: area.to_string(),
+        spec_file: spec_filename,
+        task_file: task_filename,
+        spec_path,
+        task_path,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,12 @@ fn main() -> Result<()> {
                 short,
                 content,
             } => {
+                let area = area.unwrap_or_else(|| {
+                    crate::fs::config::load_config()
+                        .ok()
+                        .map(|c| c.area)
+                        .unwrap_or_else(|| "Staging".to_string())
+                });
                 topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,10 @@ use crate::agent::{connector as agent_connector, mode as agent_mode};
 use crate::cli::{
     AreaCommands, AreaOrderCommands, AutoCommands, ConnectorCommands, IndexCommands,
     IngestCommands, ModeCommands, OrderCommands, ParseCommands, PattyCommands, PkgCommands,
-    TopicCommands,
+    SpecCommands, TopicCommands,
 };
 use crate::cli::{Cli, Commands};
-use crate::commands::{area, index, ingest, init, init_editor, repo, set, topic};
+use crate::commands::{area, index, ingest, init, init_editor, repo, set, spec, topic};
 
 fn get_show_platypus() -> bool {
     crate::fs::config::get_paddy_enabled().unwrap_or(true)
@@ -322,15 +322,48 @@ fn main() -> Result<()> {
             let path_str = path.map(|p| p.to_string_lossy().to_string());
             mcp::server::run_mcp_server(path_str.as_deref())?;
         }
-        Some(Commands::Spec { name: _ }) => {
-            let master_path = crate::fs::spec_dir().join("master.md");
-            if master_path.exists() {
-                let content = std::fs::read_to_string(&master_path)?;
-                println!("{}", content);
-            } else {
-                println!("No master spec found. Create spec/master.md to add context.");
+        Some(Commands::Spec(spec_cmd)) => match spec_cmd {
+            SpecCommands::Show { name: _ } => {
+                let master_path = crate::fs::spec_dir().join("master.md");
+                if master_path.exists() {
+                    let content = std::fs::read_to_string(&master_path)?;
+                    println!("{}", content);
+                } else {
+                    println!("No master spec found. Create spec/master.md to add context.");
+                }
             }
-        }
+            SpecCommands::Add {
+                topic,
+                area,
+                short,
+                spec_content,
+                task_content,
+            } => {
+                let area = area.unwrap_or_else(|| {
+                    crate::fs::config::load_config()
+                        .ok()
+                        .map(|c| c.area)
+                        .unwrap_or_else(|| "Staging".to_string())
+                });
+                let out = spec::run_spec_add(
+                    &topic,
+                    Some(&area),
+                    &short,
+                    &spec_content,
+                    &task_content,
+                )?;
+                println!(
+                    "✅ Spec and task created for '{}' in {}/\n  {}\n  {}",
+                    out.topic,
+                    out.area,
+                    out.spec_path.display(),
+                    out.task_path.display(),
+                );
+                if get_show_platypus() {
+                    platypus::happy();
+                }
+            }
+        },
         Some(Commands::Mode(mode_cmd)) => match mode_cmd {
             ModeCommands::List => {
                 let modes = agent_mode::list_modes()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,8 +196,13 @@ fn main() -> Result<()> {
             },
         },
         Some(Commands::Topic(topic_cmd)) => match topic_cmd {
-            TopicCommands::Add { topic, area } => {
-                topic::run_new(&topic, &area)?;
+            TopicCommands::Add {
+                topic,
+                area,
+                short,
+                content,
+            } => {
+                topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();
                 }
@@ -550,7 +555,7 @@ fn main() -> Result<()> {
                 spec_file: _,
             } => {
                 let result =
-                    crate::agent::auto::build::run_auto_build(&topic, area.as_deref(), None)?;
+                    crate::agent::auto::build::run_auto_build(topic.as_deref(), area.as_deref(), None)?;
                 println!("Build result: {:?}", result);
             }
             AutoCommands::Verify { topic, area } => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1052,128 +1052,39 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
         }
         // === Spec Add (creates <topic>_spec.md and <topic>_task.md from templates) ===
         "spec_add" => {
-            let topic = args.get("topic").and_then(|v| v.as_str()).unwrap();
-            let area = args
-                .get("area")
+            let topic = args
+                .get("topic")
                 .and_then(|v| v.as_str())
-                .unwrap_or("Staging");
-            let provided_content = args
-                .get("spec_content")
-                .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| s.len() > 10)
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires meaningful spec_content (at least 10 characters)!\n\nYour 'spec_content' was empty or too short. Include actual spec like:\n\nspec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"Description\", spec_content: \"# Design: myproject/auth\\n\\n## Overview\\n> User auth system...\", task_content: \"# Tasks: myproject/auth\\n\\n- [ ] Task 1\" }}"))?;
-            let provided_task_content = args
-                .get("task_content")
-                .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| s.len() > 10)
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires meaningful task_content (at least 10 characters)!\n\nYour 'task_content' was empty or too short. Include actual tasks like:\n\nspec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"Description\", spec_content: \"# Design: myproject/auth\\n\\n## Overview\\n> ...\", task_content: \"# Tasks: myproject/auth\\n\\n- [ ] Task 1\" }}"))?;
-
-            // Check if topic contains "/" (nested path)
-            if topic.contains('/') {
-                // For nested paths like "auth/login", check that parent exists
-                let parts: Vec<&str> = topic.split('/').collect();
-                if parts.len() >= 2 {
-                    let parent_topic = parts[0];
-                    let spec_dir_path = crate::fs::spec_dir().join(area).join(parent_topic);
-                    let spec_dir_path_lower = crate::fs::spec_dir()
-                        .join(area.to_lowercase())
-                        .join(parent_topic);
-
-                    if !spec_dir_path.exists() && !spec_dir_path_lower.exists() {
-                        return Err(anyhow::anyhow!(
-                            "Parent topic '{}' does not exist. Create it first with: topics_add {{topic: \"{}\", area: \"{}\"}}",
-                            parent_topic, parent_topic, area
-                        ));
-                    }
-                }
-            }
-
-            // Create safe filename from topic (replace / with _)
-            let topic_safe = topic.replace("/", "-").replace(" ", "-");
-
-            // Filename is <topic>_spec.md and <topic>_task.md
-            let spec_filename = format!("{}_spec.md", topic_safe);
-            let task_filename = format!("{}_task.md", topic_safe);
-
-            // Find or create the topic directory (supports nested paths like "auth/login")
-            let spec_dir = {
-                let upper = crate::fs::spec_dir().join(area).join(topic);
-                if upper.exists() {
-                    upper
-                } else {
-                    let lower = crate::fs::spec_dir().join(area.to_lowercase()).join(topic);
-                    if lower.exists() {
-                        lower
-                    } else {
-                        std::fs::create_dir_all(&upper)?;
-                        upper
-                    }
-                }
-            };
-
-            // Strip any existing frontmatter from provided content (for spec)
-            let cleaned_content = if provided_content.trim_start().starts_with("---") {
-                if let Some(end) = provided_content.find("\n---") {
-                    &provided_content[end + 5..]
-                } else {
-                    provided_content
-                }
-            } else {
-                provided_content
-            };
-
-            // Strip any existing frontmatter from task_content
-            let cleaned_task_content = if provided_task_content.trim_start().starts_with("---") {
-                if let Some(end) = provided_task_content.find("\n---") {
-                    &provided_task_content[end + 5..]
-                } else {
-                    provided_task_content
-                }
-            } else {
-                provided_task_content
-            };
-
-            // Prepend frontmatter with metadata
-            let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-            let author = crate::commands::topic::get_agent_id();
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'topic'"))?;
+            let area = args.get("area").and_then(|v| v.as_str());
             let short = args
                 .get("short")
                 .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires 'short' parameter!\n\nExample: spec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"User authentication\", spec_content: \"...\", task_content: \"...\" }}"))?;
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'short'"))?;
+            let spec_content = args
+                .get("spec_content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'spec_content'"))?;
+            let task_content = args
+                .get("task_content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'task_content'"))?;
 
-            let spec_frontmatter = format!(
-                "---\ntitle: {}\nshort: {}\ncreated: {}\nauthor: {}\nstatus: draft\n---\n\n",
-                topic, short, now, author
-            );
-            let task_frontmatter = format!(
-                "---\nspec: {}\nshort: {}\nstatus: pending\ndate: {}\n---\n\n",
+            let out = crate::commands::spec::run_spec_add(
                 topic,
+                area,
                 short,
-                now.split(' ').next().unwrap_or(&now)
-            );
-
-            let spec_full_content = format!("{}{}", spec_frontmatter, cleaned_content.trim_start());
-            let task_full_content =
-                format!("{}{}", task_frontmatter, cleaned_task_content.trim_start());
-
-            // Write files
-            let spec_path = spec_dir.join(&spec_filename);
-            let task_path = spec_dir.join(&task_filename);
-
-            std::fs::write(&spec_path, spec_full_content)?;
-            std::fs::write(&task_path, task_full_content)?;
+                spec_content,
+                task_content,
+            )?;
 
             Ok(json!({
                 "success": true,
                 "message": "Spec and task files created from templates",
-                "topic": topic,
-                "area": area,
-                "spec_file": spec_filename,
-                "task_file": task_filename
+                "topic": out.topic,
+                "area": out.area,
+                "spec_file": out.spec_file,
+                "task_file": out.task_file
             }))
         }
         // === Queue List ===


### PR DESCRIPTION
Two bugs fixed that made the tool unusable from the command line.

Bug 1: topic add always created topics in Working regardless of what area was set in .agent/config.toml. The CLI had area hardcoded to "Working" as a default. Now it reads the area field from config and falls back to Staging if no config exists.

Bug 2: there was no way to create a spec from the CLI. Spec creation only worked through MCP which means users without an AI editor connected were stuck. Added unispec spec add with --topic, --short, --spec-content, --task-content, and --area flags. The underlying logic is shared with the MCP spec_add handler so behavior is identical.