### PR TITLE
fix: CLI polish — bullets in spec add, no duplicate specs, area defaults, named push flags

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -181,12 +181,9 @@ pub enum Commands {
         /// Project directory to run MCP server for
         path: Option<PathBuf>,
     },
-    /// View the master spec
-    Spec {
-        /// Show master spec (default)
-        #[arg(default_value = "master")]
-        name: Option<String>,
-    },
+    /// Spec commands (show, add)
+    #[command(subcommand)]
+    Spec(SpecCommands),
     /// Agent mode commands
     #[command(subcommand)]
     Mode(ModeCommands),
@@ -401,6 +398,35 @@ pub enum AreaOrderCommands {
     },
     /// Reset order to default (no custom order)
     Reset,
+}
+
+#[derive(Subcommand)]
+pub enum SpecCommands {
+    /// Show the master spec (`spec/master.md`)
+    Show {
+        /// Spec name (default: master)
+        #[arg(default_value = "master")]
+        name: Option<String>,
+    },
+    /// Create a spec + task file for a topic
+    Add {
+        /// Topic name (use `parent/child` for nested topics)
+        #[arg(short, long)]
+        topic: String,
+        /// Area for the topic. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
+        /// One-line description (required)
+        #[arg(short, long)]
+        short: String,
+        /// Full spec body (matches the spec template). Required, ≥ 11 chars.
+        #[arg(long)]
+        spec_content: String,
+        /// Full task body (matches the task template). Required, ≥ 11 chars.
+        #[arg(long)]
+        task_content: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -421,10 +421,13 @@ pub enum SpecCommands {
         #[arg(short, long)]
         short: String,
         /// Full spec body (matches the spec template). Required, ≥ 11 chars.
-        #[arg(long)]
+        /// `allow_hyphen_values` lets the value contain lines starting with `- `
+        /// (markdown bullets) without clap treating them as new flags.
+        #[arg(long, allow_hyphen_values = true)]
         spec_content: String,
         /// Full task body (matches the task template). Required, ≥ 11 chars.
-        #[arg(long)]
+        /// `allow_hyphen_values` lets the value contain markdown bullets.
+        #[arg(long, allow_hyphen_values = true)]
         task_content: String,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -451,9 +451,10 @@ pub enum TopicCommands {
     },
     /// List topics in an area
     List {
-        /// Area to list topics from (default: Working)
-        #[arg(short = 'a', long, default_value = "Working")]
-        area: String,
+        /// Area to list topics from. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short = 'a', long)]
+        area: Option<String>,
         /// Show hierarchical view
         #[arg(short = 'H', long)]
         hierarchy: bool,
@@ -472,13 +473,19 @@ pub enum TopicCommands {
     Pull {
         /// Name of the topic to pull
         topic: String,
-        /// Source area to pull from
-        area: String,
+        /// Source area to pull from. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
     },
     /// Remove a topic
     Remove {
         /// Name of the topic to remove
         topic: String,
+        /// Area the topic lives in. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
         /// Force removal without confirmation
         #[arg(short, long)]
         force: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -463,10 +463,13 @@ pub enum TopicCommands {
     Push {
         /// Name of the topic to push
         topic: String,
-        /// Target area to push to
-        area: String,
-        /// Source area to push from
-        #[arg(long)]
+        /// Target area to push to. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
+        /// Source area to push from. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
         from: Option<String>,
     },
     /// Pull a topic from another area

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -409,9 +409,10 @@ pub enum TopicCommands {
     Add {
         /// Name of the topic to create
         topic: String,
-        /// Area to create the topic in (default: Working)
-        #[arg(short, long, default_value = "Working")]
-        area: String,
+        /// Area to create the topic in. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
         /// Short one-line description (required)
         #[arg(short, long)]
         short: String,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod pull;
 pub mod push;
 pub mod repo;
 pub mod set;
+pub mod spec;
 pub mod topic;

--- a/src/commands/spec.rs
+++ b/src/commands/spec.rs
@@ -1,0 +1,148 @@
+// src/commands/spec.rs
+//
+// Shared logic for creating a spec + task file for a topic. Used by both the
+// CLI (`unispec spec add ...`) and the MCP server (`spec_add` tool).
+//
+// Behaviour (preserved verbatim from the original MCP handler):
+// - `topic` may contain `/` for nested topics. The parent must already exist.
+// - `area` defaults to "Staging" when callers pass `None`. Case is preserved as
+//   provided; the function will fall back to the lowercase variant if the
+//   uppercased directory does not exist.
+// - `short` is required and non-empty.
+// - `spec_content` and `task_content` must each be at least 11 characters
+//   (`>10`) after trimming.
+// - Any leading `---` frontmatter block the caller includes in content is
+//   stripped before the function prepends its own canonical frontmatter.
+// - Files are written as `<topic-safe>_spec.md` and `<topic-safe>_task.md`
+//   where `topic-safe = topic.replace('/', "-").replace(' ', "-")`.
+
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub struct SpecAddOutput {
+    pub topic: String,
+    pub area: String,
+    pub spec_file: String,
+    pub task_file: String,
+    pub spec_path: PathBuf,
+    pub task_path: PathBuf,
+}
+
+/// Strip a leading `---` YAML frontmatter block from `content` if one is
+/// present. The first line must start with `---`; the block ends at the next
+/// line beginning with `---`.
+fn strip_frontmatter(content: &str) -> &str {
+    if content.trim_start().starts_with("---") {
+        if let Some(end) = content.find("\n---") {
+            return &content[end + 5..];
+        }
+    }
+    content
+}
+
+pub fn run_spec_add(
+    topic: &str,
+    area: Option<&str>,
+    short: &str,
+    spec_content: &str,
+    task_content: &str,
+) -> Result<SpecAddOutput> {
+    let area = area.unwrap_or("Staging");
+
+    let short = short.trim();
+    if short.is_empty() {
+        return Err(anyhow::anyhow!("'short' parameter is required and must be non-empty"));
+    }
+
+    let spec_content = spec_content.trim();
+    if spec_content.len() <= 10 {
+        return Err(anyhow::anyhow!(
+            "'spec_content' must be at least 11 characters of actual text"
+        ));
+    }
+
+    let task_content = task_content.trim();
+    if task_content.len() <= 10 {
+        return Err(anyhow::anyhow!(
+            "'task_content' must be at least 11 characters of actual text"
+        ));
+    }
+
+    // For nested topics ("auth/login"), verify the parent topic directory
+    // exists before we create a child inside it.
+    if topic.contains('/') {
+        let parts: Vec<&str> = topic.split('/').collect();
+        if parts.len() >= 2 {
+            let parent_topic = parts[0];
+            let parent_upper = crate::fs::spec_dir().join(area).join(parent_topic);
+            let parent_lower = crate::fs::spec_dir()
+                .join(area.to_lowercase())
+                .join(parent_topic);
+            if !parent_upper.exists() && !parent_lower.exists() {
+                return Err(anyhow::anyhow!(
+                    "Parent topic '{}' does not exist. Create it first with: \
+                     unispec topic add {} --area {} --short \"…\" --content \"…\"",
+                    parent_topic,
+                    parent_topic,
+                    area
+                ));
+            }
+        }
+    }
+
+    // Topic-safe filename component (matches the original MCP handler).
+    let topic_safe = topic.replace('/', "-").replace(' ', "-");
+    let spec_filename = format!("{}_spec.md", topic_safe);
+    let task_filename = format!("{}_task.md", topic_safe);
+
+    // Resolve / create the topic directory, supporting nested paths.
+    let spec_dir = {
+        let upper = crate::fs::spec_dir().join(area).join(topic);
+        if upper.exists() {
+            upper
+        } else {
+            let lower = crate::fs::spec_dir().join(area.to_lowercase()).join(topic);
+            if lower.exists() {
+                lower
+            } else {
+                std::fs::create_dir_all(&upper)?;
+                upper
+            }
+        }
+    };
+
+    let cleaned_spec = strip_frontmatter(spec_content).trim_start();
+    let cleaned_task = strip_frontmatter(task_content).trim_start();
+
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let author = crate::commands::topic::get_agent_id();
+
+    let spec_frontmatter = format!(
+        "---\ntitle: {}\nshort: {}\ncreated: {}\nauthor: {}\nstatus: draft\n---\n\n",
+        topic, short, now, author
+    );
+    let task_frontmatter = format!(
+        "---\nspec: {}\nshort: {}\nstatus: pending\ndate: {}\n---\n\n",
+        topic,
+        short,
+        now.split(' ').next().unwrap_or(&now)
+    );
+
+    let spec_full = format!("{}{}", spec_frontmatter, cleaned_spec);
+    let task_full = format!("{}{}", task_frontmatter, cleaned_task);
+
+    let spec_path = spec_dir.join(&spec_filename);
+    let task_path = spec_dir.join(&task_filename);
+
+    std::fs::write(&spec_path, spec_full)?;
+    std::fs::write(&task_path, task_full)?;
+
+    Ok(SpecAddOutput {
+        topic: topic.to_string(),
+        area: area.to_string(),
+        spec_file: spec_filename,
+        task_file: task_filename,
+        spec_path,
+        task_path,
+    })
+}

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -382,8 +382,11 @@ pub fn run_push(topic: &str, target_area: &str, source_area: Option<&str>) -> Re
     let dst_task = crate::agent::mode::get_task_filename_for_area(&target_area_normalized);
     let dst_area_file = crate::agent::mode::get_area_filename_for_area(&target_area_normalized);
 
-    // Copy files - keep source files AND create target area files from templates
-    // Only copy specs and tasks, NOT area.md (area files stay in area root)
+    // Copy every file from the source topic directory into the destination
+    // verbatim. We do not synthesise additional files under legacy filenames
+    // (the previous behaviour wrote a duplicate `specs.md`/`tasks.md` next to
+    // the agent-written `<topic>_spec.md`/`<topic>_task.md`, which produced
+    // two divergent specs in the destination).
     for entry in fs::read_dir(&src)? {
         let entry = entry?;
         let path = entry.path();
@@ -394,54 +397,11 @@ pub fn run_push(topic: &str, target_area: &str, source_area: Option<&str>) -> Re
             continue;
         }
 
-        // First, copy with original filename (keep source area files)
         let orig_dest = dst.join(&filename);
         if path.is_file() {
             fs::copy(&path, &orig_dest)?;
         } else if path.is_dir() {
             copy_dir_recursive(&path, &orig_dest)?;
-        }
-
-        // Second, if this is a spec or task file, create target version from template
-        let is_spec_file = filename == src_spec
-            || filename == dst_spec
-            || filename.ends_with("_spec.md")
-            || filename.ends_with("_specs.md")
-            || filename == "spec.md"
-            || filename == "specs.md";
-        let is_task_file = filename == src_task
-            || filename == dst_task
-            || filename.ends_with("_tasks.md")
-            || filename == "tasks.md";
-
-        if !is_spec_file && !is_task_file {
-            continue;
-        }
-
-        let target_filename = if is_spec_file {
-            dst_spec.clone()
-        } else {
-            dst_task.clone()
-        };
-
-        // Only create target file if it has a different name
-        if target_filename != filename || is_spec_file {
-            let target_dest = dst.join(&target_filename);
-
-            let mut content: String;
-
-            // Check if pushing to Build and it's a spec file
-            let is_build = target_area_normalized.to_lowercase() == "build";
-
-            if is_build && is_spec_file {
-                // Read source file and add completion metadata
-                content = fs::read_to_string(&path)?;
-                let today = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-                content = add_completion_metadata(&content, &today);
-                fs::write(&target_dest, &content)?;
-            } else if path.is_file() {
-                fs::copy(&path, &target_dest)?;
-            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,7 @@ fn main() -> Result<()> {
                 topic::run_list(&area, false)?
             }
             TopicCommands::Push { topic, area, from } => {
+                let area = resolve_area_from_config(area);
                 topic::run_push(&topic, &area, from.as_deref())?;
                 if get_show_platypus() {
                     platypus::working();

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,12 @@ fn main() -> Result<()> {
                 short,
                 content,
             } => {
+                let area = area.unwrap_or_else(|| {
+                    crate::fs::config::load_config()
+                        .ok()
+                        .map(|c| c.area)
+                        .unwrap_or_else(|| "Staging".to_string())
+                });
                 topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,17 @@ fn get_show_platypus() -> bool {
     crate::fs::config::get_paddy_enabled().unwrap_or(true)
 }
 
+/// Resolve a CLI-supplied area override to a concrete area name.
+/// Falls back to `.agent/config.toml`'s `area` field, then to "Staging".
+fn resolve_area_from_config(area: Option<String>) -> String {
+    area.unwrap_or_else(|| {
+        crate::fs::config::load_config()
+            .ok()
+            .map(|c| c.area)
+            .unwrap_or_else(|| "Staging".to_string())
+    })
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -202,18 +213,16 @@ fn main() -> Result<()> {
                 short,
                 content,
             } => {
-                let area = area.unwrap_or_else(|| {
-                    crate::fs::config::load_config()
-                        .ok()
-                        .map(|c| c.area)
-                        .unwrap_or_else(|| "Staging".to_string())
-                });
+                let area = resolve_area_from_config(area);
                 topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();
                 }
             }
-            TopicCommands::List { area, hierarchy: _ } => topic::run_list(&area, false)?,
+            TopicCommands::List { area, hierarchy: _ } => {
+                let area = resolve_area_from_config(area);
+                topic::run_list(&area, false)?
+            }
             TopicCommands::Push { topic, area, from } => {
                 topic::run_push(&topic, &area, from.as_deref())?;
                 if get_show_platypus() {
@@ -221,23 +230,29 @@ fn main() -> Result<()> {
                 }
             }
             TopicCommands::Pull { topic, area } => {
+                let area = resolve_area_from_config(area);
                 topic::run_pull(&topic, &area)?;
                 if get_show_platypus() {
                     platypus::working();
                 }
             }
-            TopicCommands::Remove { topic, force } => {
-                topic::run_delete(
-                    &topic,
-                    &crate::fs::config::load_config()?.area.as_str(),
-                    force,
-                )?;
+            TopicCommands::Remove { topic, area, force } => {
+                let area = resolve_area_from_config(area);
+                topic::run_delete(&topic, &area, force)?;
                 if get_show_platypus() {
                     platypus::sad();
                 }
             }
             TopicCommands::Show { topic, all, from } => {
-                topic::run_show(&topic, all, from.as_deref())?
+                // When neither --from nor --all is given, default to the
+                // configured area so `unispec topic show <name>` picks the
+                // expected one.
+                let resolved_from = if all {
+                    from
+                } else {
+                    Some(resolve_area_from_config(from))
+                };
+                topic::run_show(&topic, all, resolved_from.as_deref())?
             }
             TopicCommands::Progress { area } => topic::run_progress(area.as_deref())?,
             TopicCommands::Order { action } => match action {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,10 @@ use crate::agent::{connector as agent_connector, mode as agent_mode};
 use crate::cli::{
     AreaCommands, AreaOrderCommands, AutoCommands, ConnectorCommands, IndexCommands,
     IngestCommands, ModeCommands, OrderCommands, ParseCommands, PattyCommands, PkgCommands,
-    TopicCommands,
+    SpecCommands, TopicCommands,
 };
 use crate::cli::{Cli, Commands};
-use crate::commands::{area, index, ingest, init, init_editor, repo, set, topic};
+use crate::commands::{area, index, ingest, init, init_editor, repo, set, spec, topic};
 
 fn get_show_platypus() -> bool {
     crate::fs::config::get_paddy_enabled().unwrap_or(true)
@@ -322,15 +322,48 @@ fn main() -> Result<()> {
             let path_str = path.map(|p| p.to_string_lossy().to_string());
             mcp::server::run_mcp_server(path_str.as_deref())?;
         }
-        Some(Commands::Spec { name: _ }) => {
-            let master_path = crate::fs::spec_dir().join("master.md");
-            if master_path.exists() {
-                let content = std::fs::read_to_string(&master_path)?;
-                println!("{}", content);
-            } else {
-                println!("No master spec found. Create spec/master.md to add context.");
+        Some(Commands::Spec(spec_cmd)) => match spec_cmd {
+            SpecCommands::Show { name: _ } => {
+                let master_path = crate::fs::spec_dir().join("master.md");
+                if master_path.exists() {
+                    let content = std::fs::read_to_string(&master_path)?;
+                    println!("{}", content);
+                } else {
+                    println!("No master spec found. Create spec/master.md to add context.");
+                }
             }
-        }
+            SpecCommands::Add {
+                topic,
+                area,
+                short,
+                spec_content,
+                task_content,
+            } => {
+                let area = area.unwrap_or_else(|| {
+                    crate::fs::config::load_config()
+                        .ok()
+                        .map(|c| c.area)
+                        .unwrap_or_else(|| "Staging".to_string())
+                });
+                let out = spec::run_spec_add(
+                    &topic,
+                    Some(&area),
+                    &short,
+                    &spec_content,
+                    &task_content,
+                )?;
+                println!(
+                    "✅ Spec and task created for '{}' in {}/\n  {}\n  {}",
+                    out.topic,
+                    out.area,
+                    out.spec_path.display(),
+                    out.task_path.display(),
+                );
+                if get_show_platypus() {
+                    platypus::happy();
+                }
+            }
+        },
         Some(Commands::Mode(mode_cmd)) => match mode_cmd {
             ModeCommands::List => {
                 let modes = agent_mode::list_modes()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,8 +196,13 @@ fn main() -> Result<()> {
             },
         },
         Some(Commands::Topic(topic_cmd)) => match topic_cmd {
-            TopicCommands::Add { topic, area } => {
-                topic::run_new(&topic, &area)?;
+            TopicCommands::Add {
+                topic,
+                area,
+                short,
+                content,
+            } => {
+                topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();
                 }
@@ -550,7 +555,7 @@ fn main() -> Result<()> {
                 spec_file: _,
             } => {
                 let result =
-                    crate::agent::auto::build::run_auto_build(&topic, area.as_deref(), None)?;
+                    crate::agent::auto::build::run_auto_build(topic.as_deref(), area.as_deref(), None)?;
                 println!("Build result: {:?}", result);
             }
             AutoCommands::Verify { topic, area } => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1052,128 +1052,39 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
         }
         // === Spec Add (creates <topic>_spec.md and <topic>_task.md from templates) ===
         "spec_add" => {
-            let topic = args.get("topic").and_then(|v| v.as_str()).unwrap();
-            let area = args
-                .get("area")
+            let topic = args
+                .get("topic")
                 .and_then(|v| v.as_str())
-                .unwrap_or("Staging");
-            let provided_content = args
-                .get("spec_content")
-                .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| s.len() > 10)
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires meaningful spec_content (at least 10 characters)!\n\nYour 'spec_content' was empty or too short. Include actual spec like:\n\nspec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"Description\", spec_content: \"# Design: myproject/auth\\n\\n## Overview\\n> User auth system...\", task_content: \"# Tasks: myproject/auth\\n\\n- [ ] Task 1\" }}"))?;
-            let provided_task_content = args
-                .get("task_content")
-                .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| s.len() > 10)
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires meaningful task_content (at least 10 characters)!\n\nYour 'task_content' was empty or too short. Include actual tasks like:\n\nspec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"Description\", spec_content: \"# Design: myproject/auth\\n\\n## Overview\\n> ...\", task_content: \"# Tasks: myproject/auth\\n\\n- [ ] Task 1\" }}"))?;
-
-            // Check if topic contains "/" (nested path)
-            if topic.contains('/') {
-                // For nested paths like "auth/login", check that parent exists
-                let parts: Vec<&str> = topic.split('/').collect();
-                if parts.len() >= 2 {
-                    let parent_topic = parts[0];
-                    let spec_dir_path = crate::fs::spec_dir().join(area).join(parent_topic);
-                    let spec_dir_path_lower = crate::fs::spec_dir()
-                        .join(area.to_lowercase())
-                        .join(parent_topic);
-
-                    if !spec_dir_path.exists() && !spec_dir_path_lower.exists() {
-                        return Err(anyhow::anyhow!(
-                            "Parent topic '{}' does not exist. Create it first with: topics_add {{topic: \"{}\", area: \"{}\"}}",
-                            parent_topic, parent_topic, area
-                        ));
-                    }
-                }
-            }
-
-            // Create safe filename from topic (replace / with _)
-            let topic_safe = topic.replace("/", "-").replace(" ", "-");
-
-            // Filename is <topic>_spec.md and <topic>_task.md
-            let spec_filename = format!("{}_spec.md", topic_safe);
-            let task_filename = format!("{}_task.md", topic_safe);
-
-            // Find or create the topic directory (supports nested paths like "auth/login")
-            let spec_dir = {
-                let upper = crate::fs::spec_dir().join(area).join(topic);
-                if upper.exists() {
-                    upper
-                } else {
-                    let lower = crate::fs::spec_dir().join(area.to_lowercase()).join(topic);
-                    if lower.exists() {
-                        lower
-                    } else {
-                        std::fs::create_dir_all(&upper)?;
-                        upper
-                    }
-                }
-            };
-
-            // Strip any existing frontmatter from provided content (for spec)
-            let cleaned_content = if provided_content.trim_start().starts_with("---") {
-                if let Some(end) = provided_content.find("\n---") {
-                    &provided_content[end + 5..]
-                } else {
-                    provided_content
-                }
-            } else {
-                provided_content
-            };
-
-            // Strip any existing frontmatter from task_content
-            let cleaned_task_content = if provided_task_content.trim_start().starts_with("---") {
-                if let Some(end) = provided_task_content.find("\n---") {
-                    &provided_task_content[end + 5..]
-                } else {
-                    provided_task_content
-                }
-            } else {
-                provided_task_content
-            };
-
-            // Prepend frontmatter with metadata
-            let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-            let author = crate::commands::topic::get_agent_id();
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'topic'"))?;
+            let area = args.get("area").and_then(|v| v.as_str());
             let short = args
                 .get("short")
                 .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires 'short' parameter!\n\nExample: spec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"User authentication\", spec_content: \"...\", task_content: \"...\" }}"))?;
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'short'"))?;
+            let spec_content = args
+                .get("spec_content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'spec_content'"))?;
+            let task_content = args
+                .get("task_content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'task_content'"))?;
 
-            let spec_frontmatter = format!(
-                "---\ntitle: {}\nshort: {}\ncreated: {}\nauthor: {}\nstatus: draft\n---\n\n",
-                topic, short, now, author
-            );
-            let task_frontmatter = format!(
-                "---\nspec: {}\nshort: {}\nstatus: pending\ndate: {}\n---\n\n",
+            let out = crate::commands::spec::run_spec_add(
                 topic,
+                area,
                 short,
-                now.split(' ').next().unwrap_or(&now)
-            );
-
-            let spec_full_content = format!("{}{}", spec_frontmatter, cleaned_content.trim_start());
-            let task_full_content =
-                format!("{}{}", task_frontmatter, cleaned_task_content.trim_start());
-
-            // Write files
-            let spec_path = spec_dir.join(&spec_filename);
-            let task_path = spec_dir.join(&task_filename);
-
-            std::fs::write(&spec_path, spec_full_content)?;
-            std::fs::write(&task_path, task_full_content)?;
+                spec_content,
+                task_content,
+            )?;
 
             Ok(json!({
                 "success": true,
                 "message": "Spec and task files created from templates",
-                "topic": topic,
-                "area": area,
-                "spec_file": spec_filename,
-                "task_file": task_filename
+                "topic": out.topic,
+                "area": out.area,
+                "spec_file": out.spec_file,
+                "task_file": out.task_file
             }))
         }
         // === Queue List ===


### PR DESCRIPTION
Four CLI bugs fixed that were found during end-to-end testing.

Bug 1: spec add rejected task content containing markdown bullets. Any line starting with - was interpreted as a new CLI flag. Fixed by adding allow_hyphen_values = true to --spec-content and --task-content.

Bug 2: topic push was writing a duplicate legacy specs.md alongside the correct topic_spec.md in the destination area. unispec_read_spec was then reading the wrong file. Removed the entire legacy duplicate-write block from the push pipeline.

Bug 3: topic list, pull, remove, show all defaulted to Working regardless of .agent/config.toml. Extended the config-aware area resolution from PR4 to every topic subcommand. Also extracted a resolve_area_from_config helper to deduplicate the pattern.

Bug 4: topic push used a positional area argument while every other command used --area. Changed to named --area and --from flags consistent with the rest of the CLI.

Note: this PR stacks on top of pr4-cli-fixes.