### PR TITLE
fix: everything — MCP handlers, init, CLI fixes, full pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1436,7 @@ dependencies = [
  "colored",
  "crossterm",
  "dirs",
+ "include_dir",
  "indexmap",
  "itertools 0.12.1",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ walkdir = "2.4"
 regex = "1.10"
 itertools = "0.12"
 uuid = { version = "1.0", features = ["v4"] }
+include_dir = "0.7"
 
 # Tree-sitter for code parsing
 tree-sitter = "0.24"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -181,12 +181,9 @@ pub enum Commands {
         /// Project directory to run MCP server for
         path: Option<PathBuf>,
     },
-    /// View the master spec
-    Spec {
-        /// Show master spec (default)
-        #[arg(default_value = "master")]
-        name: Option<String>,
-    },
+    /// Spec commands (show, add)
+    #[command(subcommand)]
+    Spec(SpecCommands),
     /// Agent mode commands
     #[command(subcommand)]
     Mode(ModeCommands),
@@ -401,6 +398,35 @@ pub enum AreaOrderCommands {
     },
     /// Reset order to default (no custom order)
     Reset,
+}
+
+#[derive(Subcommand)]
+pub enum SpecCommands {
+    /// Show the master spec (`spec/master.md`)
+    Show {
+        /// Spec name (default: master)
+        #[arg(default_value = "master")]
+        name: Option<String>,
+    },
+    /// Create a spec + task file for a topic
+    Add {
+        /// Topic name (use `parent/child` for nested topics)
+        #[arg(short, long)]
+        topic: String,
+        /// Area for the topic. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
+        /// One-line description (required)
+        #[arg(short, long)]
+        short: String,
+        /// Full spec body (matches the spec template). Required, ≥ 11 chars.
+        #[arg(long)]
+        spec_content: String,
+        /// Full task body (matches the task template). Required, ≥ 11 chars.
+        #[arg(long)]
+        task_content: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -421,10 +421,13 @@ pub enum SpecCommands {
         #[arg(short, long)]
         short: String,
         /// Full spec body (matches the spec template). Required, ≥ 11 chars.
-        #[arg(long)]
+        /// `allow_hyphen_values` lets the value contain lines starting with `- `
+        /// (markdown bullets) without clap treating them as new flags.
+        #[arg(long, allow_hyphen_values = true)]
         spec_content: String,
         /// Full task body (matches the task template). Required, ≥ 11 chars.
-        #[arg(long)]
+        /// `allow_hyphen_values` lets the value contain markdown bullets.
+        #[arg(long, allow_hyphen_values = true)]
         task_content: String,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -451,9 +451,10 @@ pub enum TopicCommands {
     },
     /// List topics in an area
     List {
-        /// Area to list topics from (default: Working)
-        #[arg(short = 'a', long, default_value = "Working")]
-        area: String,
+        /// Area to list topics from. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short = 'a', long)]
+        area: Option<String>,
         /// Show hierarchical view
         #[arg(short = 'H', long)]
         hierarchy: bool,
@@ -472,13 +473,19 @@ pub enum TopicCommands {
     Pull {
         /// Name of the topic to pull
         topic: String,
-        /// Source area to pull from
-        area: String,
+        /// Source area to pull from. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
     },
     /// Remove a topic
     Remove {
         /// Name of the topic to remove
         topic: String,
+        /// Area the topic lives in. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
         /// Force removal without confirmation
         #[arg(short, long)]
         force: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -184,6 +184,9 @@ pub enum Commands {
     /// Spec commands (show, add)
     #[command(subcommand)]
     Spec(SpecCommands),
+    /// Readiness queue commands (add)
+    #[command(subcommand)]
+    Queue(QueueCommands),
     /// Agent mode commands
     #[command(subcommand)]
     Mode(ModeCommands),
@@ -398,6 +401,25 @@ pub enum AreaOrderCommands {
     },
     /// Reset order to default (no custom order)
     Reset,
+}
+
+#[derive(Subcommand)]
+pub enum QueueCommands {
+    /// Add a topic to an area's readiness queue (`spec/<area>/queue.md`).
+    /// Required before pushing out of areas listed under `[readiness].areas`
+    /// in `mode.toml` (default: Staging, Fixing).
+    Add {
+        /// Topic name to enqueue
+        topic: String,
+        /// Area whose queue to add to. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
+        /// 0-based position in the queue. Negative or out-of-range = append
+        /// to the end (default).
+        #[arg(short, long, default_value_t = -1)]
+        position: i32,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -463,10 +463,13 @@ pub enum TopicCommands {
     Push {
         /// Name of the topic to push
         topic: String,
-        /// Target area to push to
-        area: String,
-        /// Source area to push from
-        #[arg(long)]
+        /// Target area to push to. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
+        /// Source area to push from. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
         from: Option<String>,
     },
     /// Pull a topic from another area

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -409,9 +409,10 @@ pub enum TopicCommands {
     Add {
         /// Name of the topic to create
         topic: String,
-        /// Area to create the topic in (default: Working)
-        #[arg(short, long, default_value = "Working")]
-        area: String,
+        /// Area to create the topic in. Defaults to the `area` field in
+        /// `.agent/config.toml`, or "Staging" if no config exists.
+        #[arg(short, long)]
+        area: Option<String>,
         /// Short one-line description (required)
         #[arg(short, long)]
         short: String,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -27,8 +27,8 @@ pub fn run_init(root: Option<&std::path::Path>) -> Result<()> {
     let root = root.unwrap_or_else(|| std::path::Path::new("."));
     let spec_root = root.join("spec");
 
-    // Default areas for simple mode
-    let default_areas = ["Staging", "Working", "Build"];
+    // Default areas for the default mode pipeline
+    let default_areas = ["Staging", "Working", "Testing", "Fixing", "Build"];
 
     // Copy area templates from global areas dir (or system install dir as fallback)
     let areas_dir = crate::fs::global_config_dir().join(".agent").join("areas");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,8 +1,14 @@
 // src/commands/init.rs
 use crate::fs::ensure_dir;
 use anyhow::Result;
+use include_dir::{include_dir, Dir};
 use std::fs;
 use std::path::Path;
+
+/// `.agent/modes/default/` is embedded into the binary at compile time so
+/// `unispec init` works on a fresh `cargo install` with no system data files.
+static EMBEDDED_DEFAULT_MODE: Dir<'_> =
+    include_dir!("$CARGO_MANIFEST_DIR/.agent/modes/default");
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     if !dst.exists() {
@@ -23,96 +29,122 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Populate `<dst>` from the embedded default mode if `<dst>` is missing or empty.
+fn extract_embedded_default_mode(dst: &Path) -> Result<()> {
+    ensure_dir(dst)?;
+    EMBEDDED_DEFAULT_MODE.extract(dst)?;
+    Ok(())
+}
+
+/// Source the default mode at `dst` from the first available source:
+/// 1. `~/.config/unispec/.agent/modes/default/`
+/// 2. `/usr/share/unispec/.agent/modes/default/`
+/// 3. The embedded copy compiled into the binary.
+///
+/// No-op if `dst` already contains files.
+fn install_default_mode(dst: &Path) -> Result<&'static str> {
+    let already_populated = dst.exists()
+        && fs::read_dir(dst)
+            .map(|mut it| it.next().is_some())
+            .unwrap_or(false);
+    if already_populated {
+        return Ok("existing");
+    }
+
+    let global = crate::fs::global_modes_dir().join("default");
+    let system = crate::fs::system_modes_dir().join("default");
+
+    if global.exists() {
+        copy_dir_recursive(&global, dst)?;
+        return Ok("global");
+    }
+    if system.exists() {
+        copy_dir_recursive(&system, dst)?;
+        return Ok("system");
+    }
+
+    extract_embedded_default_mode(dst)?;
+    Ok("embedded")
+}
+
 pub fn run_init(root: Option<&std::path::Path>) -> Result<()> {
     let root = root.unwrap_or_else(|| std::path::Path::new("."));
     let spec_root = root.join("spec");
 
-    // Default areas for the default mode pipeline
+    // Default mode pipeline.
     let default_areas = ["Staging", "Working", "Testing", "Fixing", "Build"];
 
-    // Copy area templates from global areas dir (or system install dir as fallback)
-    let areas_dir = crate::fs::global_config_dir().join(".agent").join("areas");
-    let system_areas_dir = crate::fs::system_areas_dir();
+    // Ensure each area directory exists. area.md is filled below from the
+    // installed default mode (preferred) or a generic fallback.
     for area in &default_areas {
-        let area_spec_dir = spec_root.join(area);
-        ensure_dir(&area_spec_dir)?;
-        let area_path = area_spec_dir.join("area.md");
-        if !area_path.exists() {
-            let template_path = areas_dir.join(area.to_lowercase()).join("area.md");
-            let system_template = system_areas_dir.join(area.to_lowercase()).join("area.md");
-            if template_path.exists() {
-                fs::copy(&template_path, &area_path)?;
-            } else if system_template.exists() {
-                fs::copy(&system_template, &area_path)?;
-            }
-        }
+        ensure_dir(&spec_root.join(area))?;
     }
 
-    // Create .agent directory
+    // Create .agent/ + config.toml.
     let agent_root = root.join(".agent");
     ensure_dir(&agent_root)?;
+    ensure_dir(&agent_root.join("modes"))?;
 
     let config_file = agent_root.join("config.toml");
     if !config_file.exists() {
         fs::write(&config_file, CONFIG_TEMPLATE)?;
     }
 
-    // Copy simple mode from global (or system install dir as fallback)
-    let simple_mode = agent_root.join("modes").join("simple");
-    if !simple_mode.exists() {
-        ensure_dir(&simple_mode)?;
-        let global_simple = crate::fs::global_modes_dir().join("simple");
-        let system_simple = crate::fs::system_modes_dir().join("simple");
-        if global_simple.exists() {
-            copy_dir_recursive(&global_simple, &simple_mode)?;
-        } else if system_simple.exists() {
-            copy_dir_recursive(&system_simple, &simple_mode)?;
-        }
-    }
+    // Install the default mode into .agent/modes/default/.
+    let default_mode = agent_root.join("modes").join("default");
+    let source = install_default_mode(&default_mode)?;
 
-    // Copy workflows to main .agent/workflows for active use
-    let workflows_dir = agent_root.join("workflows");
-    ensure_dir(&workflows_dir)?;
-    for workflow_file in ["osdd:spec.md", "osdd:build.md", "osdd:verify.md"] {
-        let src = simple_mode.join("workflows").join(workflow_file);
-        let dst = workflows_dir.join(workflow_file);
-        if src.exists() && !dst.exists() {
-            fs::copy(&src, &dst)?;
-        }
-    }
-
-    // Create default area.md files if they don't exist
-    let default_area_content = r#"# Area: {area}
-
-This is a {area} area for organizing topics.
-
-## Purpose
-
-Add purpose description here.
-
-## Topics
-
-List topics in this area:
-"#;
+    // Populate spec/<Area>/area.md from the mode's per-area templates, falling
+    // back to a generic stub if the template is missing.
     for area in &default_areas {
-        let area_spec_dir = spec_root.join(area);
-        ensure_dir(&area_spec_dir)?;
-        let area_path = area_spec_dir.join("area.md");
-        if !area_path.exists() {
-            let content = default_area_content.replace("{area}", area);
-            fs::write(&area_path, content)?;
+        let area_md = spec_root.join(area).join("area.md");
+        if area_md.exists() {
+            continue;
+        }
+        let template = default_mode
+            .join("areas")
+            .join(area.to_lowercase())
+            .join("area.md");
+        if template.exists() {
+            fs::copy(&template, &area_md)?;
+        } else {
+            let content = DEFAULT_AREA_STUB.replace("{area}", area);
+            fs::write(&area_md, content)?;
         }
     }
 
-    // Copy skill.md to .agent for active use
-    let skill_src = simple_mode.join("skill.md");
+    // Copy every workflow shipped with the mode into .agent/workflows/ for
+    // active use. We glob the directory so future workflow additions land here
+    // automatically.
+    let workflows_dst = agent_root.join("workflows");
+    ensure_dir(&workflows_dst)?;
+    let workflows_src = default_mode.join("workflows");
+    if workflows_src.exists() {
+        for entry in fs::read_dir(&workflows_src)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let dst = workflows_dst.join(entry.file_name());
+            if !dst.exists() {
+                fs::copy(&path, &dst)?;
+            }
+        }
+    }
+
+    // Copy skill.md to .agent/ for active use.
+    let skill_src = default_mode.join("skill.md");
     let skill_dst = agent_root.join("skill.md");
     if skill_src.exists() && !skill_dst.exists() {
         fs::copy(&skill_src, &skill_dst)?;
     }
 
-    // Create modes README
-    fs::write(agent_root.join("modes").join("README.md"), MODES_README)?;
+    // Modes README.
+    let modes_readme = agent_root.join("modes").join("README.md");
+    if !modes_readme.exists() {
+        fs::write(&modes_readme, MODES_README)?;
+    }
 
     println!(
         "
@@ -124,27 +156,42 @@ List topics in this area:
      ╚═════╝ ╚═╝  ╚═══╝╚═╝    ╚══════╝╚═╝     ╚══════╝ ╚═════╝
          "
     );
-    println!("UniSpec initialized with Simple Mode! -- Meet Paddy the Pladdy");
+    println!("UniSpec initialized with default mode (source: {})", source);
+    println!("Areas: Staging → Working → Testing → Fixing → Build");
     println!();
     println!("Agent commands available:");
-    println!("  unispec --help -    Available commands, see docs for more info");
+    println!("  unispec --help        Available commands; see docs/ for more info");
     println!();
-    println!("See .agent/modes/README.md for creating custom modes!");
+    println!("See .agent/modes/README.md for creating custom modes.");
     Ok(())
 }
 
 const CONFIG_TEMPLATE: &str = r#"# UniSpec Agent Configuration
 
-# Current active mode
+# Currently active mode (matches a directory under .agent/modes/).
 current_mode = "default"
 
-# Default area for topic operations
-# default_area = "Working"
+# Default area used by tools that omit `area`.
+area = "Staging"
 
-# Protected areas that cannot be deleted
-# protected_areas = ["Staging", "Working", "Build"]
+# Areas protected from destructive operations.
+protected_areas = ["Build"]
 
-# Connectors - Custom commands that become MCP tools
+# Show the platypus mascot in the TUI.
+paddy_enabled = false
+
+# Ingest configuration - how `unispec ingest run` parses and stores code analysis.
+[ingest]
+auto_index = false
+index_on_complete = false
+capture_functions = true
+capture_structs = true
+capture_enums = true
+capture_imports = true
+output_format = "toml"
+languages = []
+
+# Connectors - shell commands exposed as MCP tools (unispec_<name>).
 # Example:
 # [[connector]]
 # name = "test"
@@ -153,23 +200,52 @@ current_mode = "default"
 # args = ["tests/", "-v"]
 "#;
 
+const DEFAULT_AREA_STUB: &str = r#"---
+area: {area}
+short: {area} area
+---
+
+# {area}
+
+## Purpose
+
+This is the {area} area. Replace this stub with a description of how topics behave here.
+
+## Guidelines
+
+- Document what kinds of work belong in this area.
+- Document what does not.
+"#;
+
 const MODES_README: &str = r#"# UniSpec Modes
 
-Modes define different agent configurations. Each mode has its own workflows and capabilities.
+A mode is a complete workflow configuration: areas, templates, workflows, skill prompt, and any per-area overrides. The default mode ships in `.agent/modes/default/` and uses the five-area pipeline:
 
-## Creating a Mode
+    Staging → Working → Testing → Fixing → Build
+
+## Creating a mode
 
 1. Create directory: `.agent/modes/<mode_name>/`
-2. Add `mode.toml` with metadata
+2. Add `mode.toml` with metadata (see `default/mode.toml` for a working example)
 3. Add `skill.md` with agent persona
 4. Add `workflows/*.md` files
-5. Add `areas/` with staging/, working/, build/ directories containing area.md
+5. Add per-area templates under `areas/<area>/area.md` (use lowercase names)
+6. Optionally add `templates/{topic,spec,task,area}.md` as global fallbacks
 
-## Global Modes
+## Activating a mode
 
-Modes in `~/.config/unispec/modes/` are available to all projects.
+Modes are activated through the CLI (not via MCP):
 
-## Area Templates
+    unispec mode list
+    unispec mode activate <mode-name>
+    unispec mode current
 
-Place area templates in `.agent/areas/<area_name>/area.md`. The init command will copy these to spec/<area_name>/area.md.
+## Search order
+
+Modes are searched in this order; first match wins:
+
+1. Local: `./.agent/modes/`
+2. Global: `~/.config/unispec/.agent/modes/`
+3. System: `/usr/share/unispec/.agent/modes/`
+4. Embedded: the `default` mode compiled into the binary (used by `unispec init` as a final fallback)
 "#;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod pull;
 pub mod push;
 pub mod repo;
 pub mod set;
+pub mod spec;
 pub mod topic;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod init;
 pub mod init_editor;
 pub mod pull;
 pub mod push;
+pub mod queue;
 pub mod repo;
 pub mod set;
 pub mod spec;

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -38,9 +38,10 @@ pub fn run_push(topic: &str, target_area: &str, source_area: Option<&str>) -> Re
     }
 
     copy_dir_recursive(&src, &dst)?;
+    fs::remove_dir_all(&src)?;
 
     Ok(format!(
-        "✅ Pushed topic '{}' from {} to {}",
+        "✅ Moved topic '{}' from {} to {}",
         topic, source_area, target_area
     ))
 }

--- a/src/commands/queue.rs
+++ b/src/commands/queue.rs
@@ -1,0 +1,64 @@
+// src/commands/queue.rs
+//
+// Shared logic for the readiness queue (`spec/<area>/queue.md`). Used by both
+// the CLI (`unispec queue add`) and the MCP server (`queue_add` tool).
+//
+// Behaviour preserved verbatim from the original MCP handler:
+// - The queue file name comes from the mode config (default: `queue.md`).
+// - If the queue file doesn't exist, a fresh one is created with a standard
+//   header.
+// - `position < 0` or `position >= items.len()` appends to the end.
+//   Anything else inserts at the 0-based slot.
+// - Existing entries are preserved in their original order.
+
+use anyhow::Result;
+
+pub struct QueueAddOutput {
+    pub topic: String,
+    pub area: String,
+    pub position: i32,
+    pub queue_file: String,
+}
+
+pub fn run_queue_add(topic: &str, area: &str, position: i32) -> Result<QueueAddOutput> {
+    let queue_file = crate::agent::mode::get_readiness_queue_file();
+    let queue_path = crate::fs::spec_dir().join(area).join(&queue_file);
+
+    let existing = if queue_path.exists() {
+        std::fs::read_to_string(&queue_path)?
+    } else {
+        String::new()
+    };
+
+    let mut items: Vec<String> = existing
+        .lines()
+        .filter(|l| l.trim().starts_with("- "))
+        .map(|l| l.trim().trim_start_matches("- ").to_string())
+        .collect();
+
+    if position < 0 || position as usize >= items.len() {
+        items.push(topic.to_string());
+    } else {
+        items.insert(position as usize, topic.to_string());
+    }
+
+    let header = "# Task Queue\n\nOrdered list of topics to work on:\n";
+    let mut content = String::from(header);
+    for item in &items {
+        content.push_str(&format!("- {}\n", item));
+    }
+
+    // Ensure the parent area directory exists so the queue file write
+    // doesn't fail on a fresh project where the area was just created.
+    if let Some(parent) = queue_path.parent() {
+        crate::fs::ensure_dir(parent)?;
+    }
+    std::fs::write(&queue_path, content)?;
+
+    Ok(QueueAddOutput {
+        topic: topic.to_string(),
+        area: area.to_string(),
+        position,
+        queue_file,
+    })
+}

--- a/src/commands/spec.rs
+++ b/src/commands/spec.rs
@@ -1,0 +1,148 @@
+// src/commands/spec.rs
+//
+// Shared logic for creating a spec + task file for a topic. Used by both the
+// CLI (`unispec spec add ...`) and the MCP server (`spec_add` tool).
+//
+// Behaviour (preserved verbatim from the original MCP handler):
+// - `topic` may contain `/` for nested topics. The parent must already exist.
+// - `area` defaults to "Staging" when callers pass `None`. Case is preserved as
+//   provided; the function will fall back to the lowercase variant if the
+//   uppercased directory does not exist.
+// - `short` is required and non-empty.
+// - `spec_content` and `task_content` must each be at least 11 characters
+//   (`>10`) after trimming.
+// - Any leading `---` frontmatter block the caller includes in content is
+//   stripped before the function prepends its own canonical frontmatter.
+// - Files are written as `<topic-safe>_spec.md` and `<topic-safe>_task.md`
+//   where `topic-safe = topic.replace('/', "-").replace(' ', "-")`.
+
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub struct SpecAddOutput {
+    pub topic: String,
+    pub area: String,
+    pub spec_file: String,
+    pub task_file: String,
+    pub spec_path: PathBuf,
+    pub task_path: PathBuf,
+}
+
+/// Strip a leading `---` YAML frontmatter block from `content` if one is
+/// present. The first line must start with `---`; the block ends at the next
+/// line beginning with `---`.
+fn strip_frontmatter(content: &str) -> &str {
+    if content.trim_start().starts_with("---") {
+        if let Some(end) = content.find("\n---") {
+            return &content[end + 5..];
+        }
+    }
+    content
+}
+
+pub fn run_spec_add(
+    topic: &str,
+    area: Option<&str>,
+    short: &str,
+    spec_content: &str,
+    task_content: &str,
+) -> Result<SpecAddOutput> {
+    let area = area.unwrap_or("Staging");
+
+    let short = short.trim();
+    if short.is_empty() {
+        return Err(anyhow::anyhow!("'short' parameter is required and must be non-empty"));
+    }
+
+    let spec_content = spec_content.trim();
+    if spec_content.len() <= 10 {
+        return Err(anyhow::anyhow!(
+            "'spec_content' must be at least 11 characters of actual text"
+        ));
+    }
+
+    let task_content = task_content.trim();
+    if task_content.len() <= 10 {
+        return Err(anyhow::anyhow!(
+            "'task_content' must be at least 11 characters of actual text"
+        ));
+    }
+
+    // For nested topics ("auth/login"), verify the parent topic directory
+    // exists before we create a child inside it.
+    if topic.contains('/') {
+        let parts: Vec<&str> = topic.split('/').collect();
+        if parts.len() >= 2 {
+            let parent_topic = parts[0];
+            let parent_upper = crate::fs::spec_dir().join(area).join(parent_topic);
+            let parent_lower = crate::fs::spec_dir()
+                .join(area.to_lowercase())
+                .join(parent_topic);
+            if !parent_upper.exists() && !parent_lower.exists() {
+                return Err(anyhow::anyhow!(
+                    "Parent topic '{}' does not exist. Create it first with: \
+                     unispec topic add {} --area {} --short \"…\" --content \"…\"",
+                    parent_topic,
+                    parent_topic,
+                    area
+                ));
+            }
+        }
+    }
+
+    // Topic-safe filename component (matches the original MCP handler).
+    let topic_safe = topic.replace('/', "-").replace(' ', "-");
+    let spec_filename = format!("{}_spec.md", topic_safe);
+    let task_filename = format!("{}_task.md", topic_safe);
+
+    // Resolve / create the topic directory, supporting nested paths.
+    let spec_dir = {
+        let upper = crate::fs::spec_dir().join(area).join(topic);
+        if upper.exists() {
+            upper
+        } else {
+            let lower = crate::fs::spec_dir().join(area.to_lowercase()).join(topic);
+            if lower.exists() {
+                lower
+            } else {
+                std::fs::create_dir_all(&upper)?;
+                upper
+            }
+        }
+    };
+
+    let cleaned_spec = strip_frontmatter(spec_content).trim_start();
+    let cleaned_task = strip_frontmatter(task_content).trim_start();
+
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let author = crate::commands::topic::get_agent_id();
+
+    let spec_frontmatter = format!(
+        "---\ntitle: {}\nshort: {}\ncreated: {}\nauthor: {}\nstatus: draft\n---\n\n",
+        topic, short, now, author
+    );
+    let task_frontmatter = format!(
+        "---\nspec: {}\nshort: {}\nstatus: pending\ndate: {}\n---\n\n",
+        topic,
+        short,
+        now.split(' ').next().unwrap_or(&now)
+    );
+
+    let spec_full = format!("{}{}", spec_frontmatter, cleaned_spec);
+    let task_full = format!("{}{}", task_frontmatter, cleaned_task);
+
+    let spec_path = spec_dir.join(&spec_filename);
+    let task_path = spec_dir.join(&task_filename);
+
+    std::fs::write(&spec_path, spec_full)?;
+    std::fs::write(&task_path, task_full)?;
+
+    Ok(SpecAddOutput {
+        topic: topic.to_string(),
+        area: area.to_string(),
+        spec_file: spec_filename,
+        task_file: task_filename,
+        spec_path,
+        task_path,
+    })
+}

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -382,8 +382,11 @@ pub fn run_push(topic: &str, target_area: &str, source_area: Option<&str>) -> Re
     let dst_task = crate::agent::mode::get_task_filename_for_area(&target_area_normalized);
     let dst_area_file = crate::agent::mode::get_area_filename_for_area(&target_area_normalized);
 
-    // Copy files - keep source files AND create target area files from templates
-    // Only copy specs and tasks, NOT area.md (area files stay in area root)
+    // Copy every file from the source topic directory into the destination
+    // verbatim. We do not synthesise additional files under legacy filenames
+    // (the previous behaviour wrote a duplicate `specs.md`/`tasks.md` next to
+    // the agent-written `<topic>_spec.md`/`<topic>_task.md`, which produced
+    // two divergent specs in the destination).
     for entry in fs::read_dir(&src)? {
         let entry = entry?;
         let path = entry.path();
@@ -394,54 +397,11 @@ pub fn run_push(topic: &str, target_area: &str, source_area: Option<&str>) -> Re
             continue;
         }
 
-        // First, copy with original filename (keep source area files)
         let orig_dest = dst.join(&filename);
         if path.is_file() {
             fs::copy(&path, &orig_dest)?;
         } else if path.is_dir() {
             copy_dir_recursive(&path, &orig_dest)?;
-        }
-
-        // Second, if this is a spec or task file, create target version from template
-        let is_spec_file = filename == src_spec
-            || filename == dst_spec
-            || filename.ends_with("_spec.md")
-            || filename.ends_with("_specs.md")
-            || filename == "spec.md"
-            || filename == "specs.md";
-        let is_task_file = filename == src_task
-            || filename == dst_task
-            || filename.ends_with("_tasks.md")
-            || filename == "tasks.md";
-
-        if !is_spec_file && !is_task_file {
-            continue;
-        }
-
-        let target_filename = if is_spec_file {
-            dst_spec.clone()
-        } else {
-            dst_task.clone()
-        };
-
-        // Only create target file if it has a different name
-        if target_filename != filename || is_spec_file {
-            let target_dest = dst.join(&target_filename);
-
-            let mut content: String;
-
-            // Check if pushing to Build and it's a spec file
-            let is_build = target_area_normalized.to_lowercase() == "build";
-
-            if is_build && is_spec_file {
-                // Read source file and add completion metadata
-                content = fs::read_to_string(&path)?;
-                let today = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-                content = add_completion_metadata(&content, &today);
-                fs::write(&target_dest, &content)?;
-            } else if path.is_file() {
-                fs::copy(&path, &target_dest)?;
-            }
         }
     }
 

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -1102,12 +1102,18 @@ pub fn auto_checkin(topic: &str, area: &str) -> Result<String> {
         ));
     }
 
-    let spec_filename = crate::agent::mode::get_spec_filename_for_area(area);
+    // Use the same `<topic>_spec.md` naming convention that `spec_add` writes.
+    // The legacy `get_spec_filename_for_area` returns the mode template name
+    // ("spec.md" / "specs.md") which doesn't match what's actually on disk.
+    let topic_safe = topic.replace('/', "-").replace(' ', "-");
+    let spec_filename = format!("{}_spec.md", topic_safe);
     let spec_path = src_path.join(&spec_filename);
 
+    // No spec file yet — nothing to check in. Don't fail the push for this.
     if !spec_path.exists() {
-        return Err(anyhow::anyhow!(
-            "❌ Spec file not found for topic '{}'.",
+        return Ok(format!(
+            "ℹ️  No spec file at {} for '{}'; skipping auto-checkin.",
+            spec_path.display(),
             topic
         ));
     }

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -257,18 +257,30 @@ pub fn run_push(topic: &str, target_area: &str, source_area: Option<&str>) -> Re
     let source_area_normalized = crate::fs::normalize_area_name(&source_area);
     let target_area_normalized = crate::fs::normalize_area_name(target_area);
 
-    // Check if areas exist
+    // Source must exist — we can't push from nowhere.
     if !crate::fs::area_exists(&source_area_normalized) {
         return Err(anyhow::anyhow!(
             "❌ Source area '{}' not found.",
             source_area
         ));
     }
+
+    // Auto-create the target area if it isn't present. Workaround for setups
+    // where `unispec init` didn't create the full 5-area pipeline (e.g. the
+    // current init still ships Staging/Working/Build only). With this in
+    // place, pushing to Testing or Fixing for the first time creates the
+    // area directory + a minimal area.md on demand.
     if !crate::fs::area_exists(&target_area_normalized) {
-        return Err(anyhow::anyhow!(
-            "❌ Target area '{}' not found.",
-            target_area
-        ));
+        let target_area_dir = crate::fs::spec_dir().join(&target_area_normalized);
+        ensure_dir(&target_area_dir)?;
+        let target_area_md = target_area_dir.join("area.md");
+        if !target_area_md.exists() {
+            let stub = format!(
+                "---\narea: {area}\nshort: {area} area\n---\n\n# {area}\n\n## Purpose\n\nAuto-created by `unispec topic push` because the area didn't exist yet.\n",
+                area = target_area_normalized
+            );
+            fs::write(&target_area_md, stub)?;
+        }
     }
 
     if source_area_normalized.to_lowercase() == target_area_normalized.to_lowercase() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,7 @@ fn main() -> Result<()> {
                 topic::run_list(&area, false)?
             }
             TopicCommands::Push { topic, area, from } => {
+                let area = resolve_area_from_config(area);
                 topic::run_push(&topic, &area, from.as_deref())?;
                 if get_show_platypus() {
                     platypus::working();

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,12 @@ fn main() -> Result<()> {
                 short,
                 content,
             } => {
+                let area = area.unwrap_or_else(|| {
+                    crate::fs::config::load_config()
+                        .ok()
+                        .map(|c| c.area)
+                        .unwrap_or_else(|| "Staging".to_string())
+                });
                 topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,17 @@ fn get_show_platypus() -> bool {
     crate::fs::config::get_paddy_enabled().unwrap_or(true)
 }
 
+/// Resolve a CLI-supplied area override to a concrete area name.
+/// Falls back to `.agent/config.toml`'s `area` field, then to "Staging".
+fn resolve_area_from_config(area: Option<String>) -> String {
+    area.unwrap_or_else(|| {
+        crate::fs::config::load_config()
+            .ok()
+            .map(|c| c.area)
+            .unwrap_or_else(|| "Staging".to_string())
+    })
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -202,18 +213,16 @@ fn main() -> Result<()> {
                 short,
                 content,
             } => {
-                let area = area.unwrap_or_else(|| {
-                    crate::fs::config::load_config()
-                        .ok()
-                        .map(|c| c.area)
-                        .unwrap_or_else(|| "Staging".to_string())
-                });
+                let area = resolve_area_from_config(area);
                 topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();
                 }
             }
-            TopicCommands::List { area, hierarchy: _ } => topic::run_list(&area, false)?,
+            TopicCommands::List { area, hierarchy: _ } => {
+                let area = resolve_area_from_config(area);
+                topic::run_list(&area, false)?
+            }
             TopicCommands::Push { topic, area, from } => {
                 topic::run_push(&topic, &area, from.as_deref())?;
                 if get_show_platypus() {
@@ -221,23 +230,29 @@ fn main() -> Result<()> {
                 }
             }
             TopicCommands::Pull { topic, area } => {
+                let area = resolve_area_from_config(area);
                 topic::run_pull(&topic, &area)?;
                 if get_show_platypus() {
                     platypus::working();
                 }
             }
-            TopicCommands::Remove { topic, force } => {
-                topic::run_delete(
-                    &topic,
-                    &crate::fs::config::load_config()?.area.as_str(),
-                    force,
-                )?;
+            TopicCommands::Remove { topic, area, force } => {
+                let area = resolve_area_from_config(area);
+                topic::run_delete(&topic, &area, force)?;
                 if get_show_platypus() {
                     platypus::sad();
                 }
             }
             TopicCommands::Show { topic, all, from } => {
-                topic::run_show(&topic, all, from.as_deref())?
+                // When neither --from nor --all is given, default to the
+                // configured area so `unispec topic show <name>` picks the
+                // expected one.
+                let resolved_from = if all {
+                    from
+                } else {
+                    Some(resolve_area_from_config(from))
+                };
+                topic::run_show(&topic, all, resolved_from.as_deref())?
             }
             TopicCommands::Progress { area } => topic::run_progress(area.as_deref())?,
             TopicCommands::Order { action } => match action {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,10 @@ use crate::agent::{connector as agent_connector, mode as agent_mode};
 use crate::cli::{
     AreaCommands, AreaOrderCommands, AutoCommands, ConnectorCommands, IndexCommands,
     IngestCommands, ModeCommands, OrderCommands, ParseCommands, PattyCommands, PkgCommands,
-    TopicCommands,
+    SpecCommands, TopicCommands,
 };
 use crate::cli::{Cli, Commands};
-use crate::commands::{area, index, ingest, init, init_editor, repo, set, topic};
+use crate::commands::{area, index, ingest, init, init_editor, repo, set, spec, topic};
 
 fn get_show_platypus() -> bool {
     crate::fs::config::get_paddy_enabled().unwrap_or(true)
@@ -322,15 +322,48 @@ fn main() -> Result<()> {
             let path_str = path.map(|p| p.to_string_lossy().to_string());
             mcp::server::run_mcp_server(path_str.as_deref())?;
         }
-        Some(Commands::Spec { name: _ }) => {
-            let master_path = crate::fs::spec_dir().join("master.md");
-            if master_path.exists() {
-                let content = std::fs::read_to_string(&master_path)?;
-                println!("{}", content);
-            } else {
-                println!("No master spec found. Create spec/master.md to add context.");
+        Some(Commands::Spec(spec_cmd)) => match spec_cmd {
+            SpecCommands::Show { name: _ } => {
+                let master_path = crate::fs::spec_dir().join("master.md");
+                if master_path.exists() {
+                    let content = std::fs::read_to_string(&master_path)?;
+                    println!("{}", content);
+                } else {
+                    println!("No master spec found. Create spec/master.md to add context.");
+                }
             }
-        }
+            SpecCommands::Add {
+                topic,
+                area,
+                short,
+                spec_content,
+                task_content,
+            } => {
+                let area = area.unwrap_or_else(|| {
+                    crate::fs::config::load_config()
+                        .ok()
+                        .map(|c| c.area)
+                        .unwrap_or_else(|| "Staging".to_string())
+                });
+                let out = spec::run_spec_add(
+                    &topic,
+                    Some(&area),
+                    &short,
+                    &spec_content,
+                    &task_content,
+                )?;
+                println!(
+                    "✅ Spec and task created for '{}' in {}/\n  {}\n  {}",
+                    out.topic,
+                    out.area,
+                    out.spec_path.display(),
+                    out.task_path.display(),
+                );
+                if get_show_platypus() {
+                    platypus::happy();
+                }
+            }
+        },
         Some(Commands::Mode(mode_cmd)) => match mode_cmd {
             ModeCommands::List => {
                 let modes = agent_mode::list_modes()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,10 @@ use crate::agent::{connector as agent_connector, mode as agent_mode};
 use crate::cli::{
     AreaCommands, AreaOrderCommands, AutoCommands, ConnectorCommands, IndexCommands,
     IngestCommands, ModeCommands, OrderCommands, ParseCommands, PattyCommands, PkgCommands,
-    SpecCommands, TopicCommands,
+    QueueCommands, SpecCommands, TopicCommands,
 };
 use crate::cli::{Cli, Commands};
-use crate::commands::{area, index, ingest, init, init_editor, repo, set, spec, topic};
+use crate::commands::{area, index, ingest, init, init_editor, queue, repo, set, spec, topic};
 
 fn get_show_platypus() -> bool {
     crate::fs::config::get_paddy_enabled().unwrap_or(true)
@@ -374,6 +374,30 @@ fn main() -> Result<()> {
                     out.area,
                     out.spec_path.display(),
                     out.task_path.display(),
+                );
+                if get_show_platypus() {
+                    platypus::happy();
+                }
+            }
+        },
+        Some(Commands::Queue(queue_cmd)) => match queue_cmd {
+            QueueCommands::Add {
+                topic,
+                area,
+                position,
+            } => {
+                let area = resolve_area_from_config(area);
+                let out = queue::run_queue_add(&topic, &area, position)?;
+                println!(
+                    "✅ Added '{}' to {}/{} at position {}",
+                    out.topic,
+                    out.area,
+                    out.queue_file,
+                    if out.position < 0 {
+                        "end".to_string()
+                    } else {
+                        out.position.to_string()
+                    }
                 );
                 if get_show_platypus() {
                     platypus::happy();

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,8 +196,13 @@ fn main() -> Result<()> {
             },
         },
         Some(Commands::Topic(topic_cmd)) => match topic_cmd {
-            TopicCommands::Add { topic, area } => {
-                topic::run_new(&topic, &area)?;
+            TopicCommands::Add {
+                topic,
+                area,
+                short,
+                content,
+            } => {
+                topic::run_new(&topic, &area, Some(&short), Some(&content))?;
                 if get_show_platypus() {
                     platypus::happy();
                 }
@@ -550,7 +555,7 @@ fn main() -> Result<()> {
                 spec_file: _,
             } => {
                 let result =
-                    crate::agent::auto::build::run_auto_build(&topic, area.as_deref(), None)?;
+                    crate::agent::auto::build::run_auto_build(topic.as_deref(), area.as_deref(), None)?;
                 println!("Build result: {:?}", result);
             }
             AutoCommands::Verify { topic, area } => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1162,46 +1162,24 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
         }
         // === Queue Add ===
         "queue_add" => {
-            let topic = args.get("topic").and_then(|v| v.as_str()).unwrap();
+            let topic = args
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("queue_add requires 'topic'"))?;
             let position = args.get("position").and_then(|v| v.as_i64()).unwrap_or(-1) as i32;
             let area = args
                 .get("area")
                 .and_then(|v| v.as_str())
                 .unwrap_or("Staging");
 
-            let queue_file = crate::agent::mode::get_readiness_queue_file();
-            let queue_path = crate::fs::spec_dir().join(area).join(&queue_file);
-            let mut content = if queue_path.exists() {
-                std::fs::read_to_string(&queue_path)?
-            } else {
-                "# Task Queue\n\nOrdered list of topics to work on:\n".to_string()
-            };
-
-            // Parse existing items
-            let mut items: Vec<String> = content
-                .lines()
-                .filter(|l| l.trim().starts_with("- "))
-                .map(|l| l.trim().trim_start_matches("- ").to_string())
-                .collect();
-
-            // Add topic at position
-            if position < 0 || position as usize >= items.len() {
-                items.push(topic.to_string());
-            } else {
-                items.insert(position as usize, topic.to_string());
-            }
-
-            // Rebuild content
-            let header = "# Task Queue\n\nOrdered list of topics to work on:\n";
-            content = header.to_string();
-            for item in items {
-                content.push_str(&format!("- {}\n", item));
-            }
-
-            std::fs::write(&queue_path, content)?;
-            Ok(
-                json!({ "success": true, "message": format!("Added '{}' to queue at position {}", topic, position), "topic": topic, "area": area, "queue_file": queue_file }),
-            )
+            let out = crate::commands::queue::run_queue_add(topic, area, position)?;
+            Ok(json!({
+                "success": true,
+                "message": format!("Added '{}' to queue at position {}", out.topic, out.position),
+                "topic": out.topic,
+                "area": out.area,
+                "queue_file": out.queue_file
+            }))
         }
         // === Queue Remove ===
         "queue_remove" => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -140,9 +140,10 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
                 }
             }
 
+            let topic_safe = topic.replace('/', "-").replace(' ', "-");
             let file_path = match asset_type {
                 "spec" => {
-                    let spec_filename = crate::agent::mode::get_spec_filename_for_area(area);
+                    let spec_filename = format!("{}_spec.md", topic_safe);
                     let spec_path_upper = crate::fs::spec_dir()
                         .join(area)
                         .join(topic)
@@ -157,14 +158,15 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
                         spec_path_lower
                     } else {
                         return Err(anyhow::anyhow!(
-                            "Spec file not found for topic '{}' in area '{}'",
+                            "Spec file '{}' not found for topic '{}' in area '{}'",
+                            spec_filename,
                             topic,
                             area
                         ));
                     }
                 }
                 "task" => {
-                    let task_filename = crate::agent::mode::get_task_filename_for_area(area);
+                    let task_filename = format!("{}_task.md", topic_safe);
                     let task_path_upper = crate::fs::spec_dir()
                         .join(area)
                         .join(topic)
@@ -179,7 +181,8 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
                         task_path_lower
                     } else {
                         return Err(anyhow::anyhow!(
-                            "Task file not found for topic '{}' in area '{}'",
+                            "Task file '{}' not found for topic '{}' in area '{}'",
+                            task_filename,
                             topic,
                             area
                         ));
@@ -565,13 +568,17 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
             Ok(json!({ "success": true, "areas": topics }))
         }
         "unispec_read_spec" => {
-            let topic = args.get("topic").and_then(|v| v.as_str()).unwrap();
+            let topic = args
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("unispec_read_spec requires 'topic'"))?;
             let area = args
                 .get("area")
                 .and_then(|v| v.as_str())
                 .unwrap_or("Staging");
-            let spec_filename = crate::agent::mode::get_spec_filename_for_area(area);
-            let task_filename = crate::agent::mode::get_task_filename_for_area(area);
+            let topic_safe = topic.replace('/', "-").replace(' ', "-");
+            let spec_filename = format!("{}_spec.md", topic_safe);
+            let task_filename = format!("{}_task.md", topic_safe);
             let spec_path = crate::fs::spec_dir()
                 .join(area)
                 .join(topic)
@@ -580,8 +587,24 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
                 .join(area)
                 .join(topic)
                 .join(&task_filename);
-            let spec = std::fs::read_to_string(spec_path).unwrap_or_default();
-            let tasks = std::fs::read_to_string(task_path).unwrap_or_default();
+            if !spec_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Spec file '{}' not found for topic '{}' in area '{}'",
+                    spec_filename,
+                    topic,
+                    area
+                ));
+            }
+            if !task_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Task file '{}' not found for topic '{}' in area '{}'",
+                    task_filename,
+                    topic,
+                    area
+                ));
+            }
+            let spec = std::fs::read_to_string(&spec_path)?;
+            let tasks = std::fs::read_to_string(&task_path)?;
             Ok(
                 json!({ "success": true, "spec": spec, "tasks": tasks, "spec_file": spec_filename, "task_file": task_filename }),
             )

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3,6 +3,39 @@ use anyhow::Result;
 use serde_json::{json, Value};
 use std::io::{Read, Write};
 
+/// Resolve the on-disk path for `<topic>_<suffix>.md`, trying upper-cased then lower-cased area.
+fn resolve_topic_file(area: &str, topic: &str, suffix: &str) -> (std::path::PathBuf, String) {
+    let topic_safe = topic.replace('/', "-").replace(' ', "-");
+    let filename = format!("{}_{}.md", topic_safe, suffix);
+    let upper = crate::fs::spec_dir().join(area).join(topic).join(&filename);
+    let lower = crate::fs::spec_dir()
+        .join(area.to_lowercase())
+        .join(topic)
+        .join(&filename);
+    if upper.exists() {
+        (upper, filename)
+    } else if lower.exists() {
+        (lower, filename)
+    } else {
+        (upper, filename)
+    }
+}
+
+/// Replace the contents of the first `[...]` checkbox marker on `line` with `new_state`.
+fn replace_first_checkbox(line: &str, new_state: &str) -> String {
+    if let Some(open) = line.find('[') {
+        if let Some(close_rel) = line[open + 1..].find(']') {
+            let close = open + 1 + close_rel;
+            let mut out = String::with_capacity(line.len());
+            out.push_str(&line[..open + 1]);
+            out.push_str(new_state);
+            out.push_str(&line[close..]);
+            return out;
+        }
+    }
+    line.to_string()
+}
+
 fn call_tool(name: &str, args: &Value) -> Result<Value> {
     match name {
         "topics_list" => {
@@ -1324,6 +1357,270 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
                 },
                 "topic": topic,
                 "area": area,
+                "queue_file": queue_file
+            }))
+        }
+        // === Tasks List ===
+        "tasks_list" => {
+            let topic = args
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("tasks_list requires 'topic'"))?;
+            let area = args
+                .get("area")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Staging");
+            let (task_path, task_filename) = resolve_topic_file(area, topic, "task");
+            if !task_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Task file '{}' not found for topic '{}' in area '{}'",
+                    task_filename,
+                    topic,
+                    area
+                ));
+            }
+            let content = std::fs::read_to_string(&task_path)?;
+            let mut tasks = vec![];
+            for (line_no, line) in content.lines().enumerate() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with("- [") {
+                    let status = if trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]") {
+                        "complete"
+                    } else {
+                        "pending"
+                    };
+                    let text = trimmed
+                        .splitn(2, ']')
+                        .nth(1)
+                        .map(|s| s.trim())
+                        .unwrap_or("");
+                    let index = tasks.len();
+                    tasks.push(json!({
+                        "index": index,
+                        "line": line_no,
+                        "status": status,
+                        "text": text
+                    }));
+                }
+            }
+            let count = tasks.len();
+            Ok(json!({
+                "success": true,
+                "topic": topic,
+                "area": area,
+                "tasks": tasks,
+                "count": count
+            }))
+        }
+        // === Tasks Complete / Incomplete ===
+        "tasks_complete" | "tasks_incomplete" => {
+            let topic = args
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("{} requires 'topic'", name))?;
+            let task_index = args
+                .get("task_index")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("{} requires 'task_index' (integer >= 0)", name))?
+                as usize;
+            let area = args
+                .get("area")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Staging");
+            let (task_path, task_filename) = resolve_topic_file(area, topic, "task");
+            if !task_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Task file '{}' not found for topic '{}' in area '{}'",
+                    task_filename,
+                    topic,
+                    area
+                ));
+            }
+            let content = std::fs::read_to_string(&task_path)?;
+            let mut lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+            let mut seen = 0usize;
+            let mut target_line: Option<usize> = None;
+            for (i, line) in lines.iter().enumerate() {
+                if line.trim_start().starts_with("- [") {
+                    if seen == task_index {
+                        target_line = Some(i);
+                        break;
+                    }
+                    seen += 1;
+                }
+            }
+            let line_idx = target_line.ok_or_else(|| {
+                let total = lines
+                    .iter()
+                    .filter(|l| l.trim_start().starts_with("- ["))
+                    .count();
+                anyhow::anyhow!(
+                    "Task index {} out of range (file has {} task(s))",
+                    task_index,
+                    total
+                )
+            })?;
+            let new_state = if name == "tasks_complete" { "x" } else { " " };
+            lines[line_idx] = replace_first_checkbox(&lines[line_idx], new_state);
+            let mut new_content = lines.join("\n");
+            if content.ends_with('\n') {
+                new_content.push('\n');
+            }
+            std::fs::write(&task_path, new_content)?;
+            let status = if name == "tasks_complete" {
+                "complete"
+            } else {
+                "pending"
+            };
+            Ok(json!({
+                "success": true,
+                "topic": topic,
+                "area": area,
+                "task_index": task_index,
+                "status": status
+            }))
+        }
+        // === Notes Read ===
+        "notes_read" => {
+            let topic = args
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("notes_read requires 'topic'"))?;
+            let area = args
+                .get("area")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Staging");
+            let (task_path, task_filename) = resolve_topic_file(area, topic, "task");
+            if !task_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Task file '{}' not found for topic '{}' in area '{}'",
+                    task_filename,
+                    topic,
+                    area
+                ));
+            }
+            let content = std::fs::read_to_string(&task_path)?;
+            let notes = match content.find("## Notes") {
+                Some(idx) => {
+                    let after = &content[idx..];
+                    let mut iter = after.lines();
+                    iter.next();
+                    iter.collect::<Vec<_>>().join("\n").trim().to_string()
+                }
+                None => String::new(),
+            };
+            Ok(json!({
+                "success": true,
+                "topic": topic,
+                "area": area,
+                "notes": notes
+            }))
+        }
+        // === Notes Add ===
+        "notes_add" => {
+            let topic = args
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("notes_add requires 'topic'"))?;
+            let note = args
+                .get("note")
+                .and_then(|v| v.as_str())
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("notes_add requires non-empty 'note'"))?;
+            let area = args
+                .get("area")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Staging");
+            let (task_path, task_filename) = resolve_topic_file(area, topic, "task");
+            if !task_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Task file '{}' not found for topic '{}' in area '{}'",
+                    task_filename,
+                    topic,
+                    area
+                ));
+            }
+            let date = chrono::Local::now().format("%Y-%m-%d").to_string();
+            let note_line = format!("- **{}**: {}", date, note);
+            let mut content = std::fs::read_to_string(&task_path)?;
+            if content.contains("## Notes") {
+                if !content.ends_with('\n') {
+                    content.push('\n');
+                }
+                content.push_str(&note_line);
+                content.push('\n');
+            } else {
+                if !content.ends_with('\n') {
+                    content.push('\n');
+                }
+                content.push_str("\n## Notes\n\n");
+                content.push_str(&note_line);
+                content.push('\n');
+            }
+            std::fs::write(&task_path, content)?;
+            Ok(json!({
+                "success": true,
+                "topic": topic,
+                "area": area,
+                "appended": note_line
+            }))
+        }
+        // === Queue Reorder ===
+        "queue_reorder" => {
+            let topic = args
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("queue_reorder requires 'topic'"))?;
+            let new_position = args
+                .get("new_position")
+                .and_then(|v| v.as_i64())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("queue_reorder requires 'new_position' (integer)")
+                })?;
+            let area = args
+                .get("area")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Staging");
+            let queue_file = crate::agent::mode::get_readiness_queue_file();
+            let queue_path = crate::fs::spec_dir().join(area).join(&queue_file);
+            if !queue_path.exists() {
+                return Err(anyhow::anyhow!(
+                    "Queue file '{}' not found in area '{}'",
+                    queue_file,
+                    area
+                ));
+            }
+            let content = std::fs::read_to_string(&queue_path)?;
+            let mut items: Vec<String> = content
+                .lines()
+                .filter(|l| l.trim().starts_with("- "))
+                .map(|l| l.trim().trim_start_matches("- ").to_string())
+                .collect();
+            let current = items
+                .iter()
+                .position(|t| t == topic)
+                .ok_or_else(|| anyhow::anyhow!("Topic '{}' is not in the queue", topic))?;
+            let item = items.remove(current);
+            let insert_at = if new_position < 0 {
+                items.len()
+            } else if (new_position as usize) > items.len() {
+                items.len()
+            } else {
+                new_position as usize
+            };
+            items.insert(insert_at, item);
+            let header = "# Task Queue\n\nOrdered list of topics to work on:\n";
+            let mut new_content = String::from(header);
+            for entry in &items {
+                new_content.push_str(&format!("- {}\n", entry));
+            }
+            std::fs::write(&queue_path, new_content)?;
+            Ok(json!({
+                "success": true,
+                "topic": topic,
+                "area": area,
+                "new_position": insert_at,
                 "queue_file": queue_file
             }))
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1108,128 +1108,39 @@ fn call_tool(name: &str, args: &Value) -> Result<Value> {
         }
         // === Spec Add (creates <topic>_spec.md and <topic>_task.md from templates) ===
         "spec_add" => {
-            let topic = args.get("topic").and_then(|v| v.as_str()).unwrap();
-            let area = args
-                .get("area")
+            let topic = args
+                .get("topic")
                 .and_then(|v| v.as_str())
-                .unwrap_or("Staging");
-            let provided_content = args
-                .get("spec_content")
-                .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| s.len() > 10)
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires meaningful spec_content (at least 10 characters)!\n\nYour 'spec_content' was empty or too short. Include actual spec like:\n\nspec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"Description\", spec_content: \"# Design: myproject/auth\\n\\n## Overview\\n> User auth system...\", task_content: \"# Tasks: myproject/auth\\n\\n- [ ] Task 1\" }}"))?;
-            let provided_task_content = args
-                .get("task_content")
-                .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| s.len() > 10)
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires meaningful task_content (at least 10 characters)!\n\nYour 'task_content' was empty or too short. Include actual tasks like:\n\nspec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"Description\", spec_content: \"# Design: myproject/auth\\n\\n## Overview\\n> ...\", task_content: \"# Tasks: myproject/auth\\n\\n- [ ] Task 1\" }}"))?;
-
-            // Check if topic contains "/" (nested path)
-            if topic.contains('/') {
-                // For nested paths like "auth/login", check that parent exists
-                let parts: Vec<&str> = topic.split('/').collect();
-                if parts.len() >= 2 {
-                    let parent_topic = parts[0];
-                    let spec_dir_path = crate::fs::spec_dir().join(area).join(parent_topic);
-                    let spec_dir_path_lower = crate::fs::spec_dir()
-                        .join(area.to_lowercase())
-                        .join(parent_topic);
-
-                    if !spec_dir_path.exists() && !spec_dir_path_lower.exists() {
-                        return Err(anyhow::anyhow!(
-                            "Parent topic '{}' does not exist. Create it first with: topics_add {{topic: \"{}\", area: \"{}\"}}",
-                            parent_topic, parent_topic, area
-                        ));
-                    }
-                }
-            }
-
-            // Create safe filename from topic (replace / with _)
-            let topic_safe = topic.replace("/", "-").replace(" ", "-");
-
-            // Filename is <topic>_spec.md and <topic>_task.md
-            let spec_filename = format!("{}_spec.md", topic_safe);
-            let task_filename = format!("{}_task.md", topic_safe);
-
-            // Find or create the topic directory (supports nested paths like "auth/login")
-            let spec_dir = {
-                let upper = crate::fs::spec_dir().join(area).join(topic);
-                if upper.exists() {
-                    upper
-                } else {
-                    let lower = crate::fs::spec_dir().join(area.to_lowercase()).join(topic);
-                    if lower.exists() {
-                        lower
-                    } else {
-                        std::fs::create_dir_all(&upper)?;
-                        upper
-                    }
-                }
-            };
-
-            // Strip any existing frontmatter from provided content (for spec)
-            let cleaned_content = if provided_content.trim_start().starts_with("---") {
-                if let Some(end) = provided_content.find("\n---") {
-                    &provided_content[end + 5..]
-                } else {
-                    provided_content
-                }
-            } else {
-                provided_content
-            };
-
-            // Strip any existing frontmatter from task_content
-            let cleaned_task_content = if provided_task_content.trim_start().starts_with("---") {
-                if let Some(end) = provided_task_content.find("\n---") {
-                    &provided_task_content[end + 5..]
-                } else {
-                    provided_task_content
-                }
-            } else {
-                provided_task_content
-            };
-
-            // Prepend frontmatter with metadata
-            let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-            let author = crate::commands::topic::get_agent_id();
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'topic'"))?;
+            let area = args.get("area").and_then(|v| v.as_str());
             let short = args
                 .get("short")
                 .and_then(|v| v.as_str())
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| anyhow::anyhow!("🚫 FAILED! spec_add requires 'short' parameter!\n\nExample: spec_add {{ topic: \"myproject/auth\", area: \"Staging\", short: \"User authentication\", spec_content: \"...\", task_content: \"...\" }}"))?;
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'short'"))?;
+            let spec_content = args
+                .get("spec_content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'spec_content'"))?;
+            let task_content = args
+                .get("task_content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("spec_add requires 'task_content'"))?;
 
-            let spec_frontmatter = format!(
-                "---\ntitle: {}\nshort: {}\ncreated: {}\nauthor: {}\nstatus: draft\n---\n\n",
-                topic, short, now, author
-            );
-            let task_frontmatter = format!(
-                "---\nspec: {}\nshort: {}\nstatus: pending\ndate: {}\n---\n\n",
+            let out = crate::commands::spec::run_spec_add(
                 topic,
+                area,
                 short,
-                now.split(' ').next().unwrap_or(&now)
-            );
-
-            let spec_full_content = format!("{}{}", spec_frontmatter, cleaned_content.trim_start());
-            let task_full_content =
-                format!("{}{}", task_frontmatter, cleaned_task_content.trim_start());
-
-            // Write files
-            let spec_path = spec_dir.join(&spec_filename);
-            let task_path = spec_dir.join(&task_filename);
-
-            std::fs::write(&spec_path, spec_full_content)?;
-            std::fs::write(&task_path, task_full_content)?;
+                spec_content,
+                task_content,
+            )?;
 
             Ok(json!({
                 "success": true,
                 "message": "Spec and task files created from templates",
-                "topic": topic,
-                "area": area,
-                "spec_file": spec_filename,
-                "task_file": task_filename
+                "topic": out.topic,
+                "area": out.area,
+                "spec_file": out.spec_file,
+                "task_file": out.task_file
             }))
         }
         // === Queue List ===


### PR DESCRIPTION
This combines all fixes from PR2 through PR6 into one branch for easier review and merging.

What was broken and is now fixed:

MCP tools: 6 tools were advertised by get_tools() but returned "Unknown tool" on every call. tasks_list, tasks_complete, tasks_incomplete, notes_read, notes_add, queue_reorder are all implemented now.

MCP read: unispec_read_spec and read_asset were reading spec.md and task.md but spec_add writes topic_spec.md and topic_task.md. They silently returned empty content. Fixed to use the correct filenames.

Init: unispec init only created 3 areas. Now creates all 5 (Staging, Working, Testing, Fixing, Build). Default mode assets (templates, workflows, skill.md) are embedded in the binary so they ship on cargo install with no external setup needed.

Push: topics_push was copying instead of moving. Source directory is now removed after copy.

Push duplicates: push was writing a duplicate legacy specs.md alongside the correct topic_spec.md. Removed the duplicate write.

Push to Build: auto_checkin was looking for legacy specs.md and erroring even when the correct file existed. Fixed to use the topic_spec.md convention.

Missing areas: push to Testing or Fixing failed because init didn't create them. Push now auto-creates missing target areas on demand.

CLI area defaults: topic add, list, push, pull, remove all defaulted to Working regardless of config. All now read the area field from .agent/config.toml and fall back to Staging.

spec add command: no CLI command existed to create specs. Added unispec spec add with --topic, --short, --spec-content, --task-content flags.

spec add bullets: --task-content rejected values with markdown bullets. Fixed with allow_hyphen_values.

topic push flags: push used positional area argument while everything else used --area. Changed to named --area and --from flags.

Compile errors: 3 pre-existing compile errors in main.rs fixed as preflight.

Tested: full pipeline Staging → Working → Testing → Fixing → Build works end to end. MCP server handles all tool calls correctly.